### PR TITLE
Add option stability and similarity_boost to Eleven_Labs_Synthesizer

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -129,6 +129,8 @@ ELEVEN_LABS_ADAM_VOICE_ID = "pNInz6obpgDQGcFmaJgB"
 class ElevenLabsSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.ELEVEN_LABS):
     api_key: Optional[str] = None
     voice_id: Optional[str] = ELEVEN_LABS_ADAM_VOICE_ID
+    stability: Optional[float] = 0.75
+    similarity_boost: Optional[float] = 0.75
 
     @validator("voice_id")
     def set_name(cls, voice_id):
@@ -140,12 +142,16 @@ class ElevenLabsSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.ELEVEN
         output_device: BaseOutputDevice,
         api_key: Optional[str] = None,
         voice_id: Optional[str] = None,
+        stability: Optional[float] = None,
+        similarity_boost: Optional[float] = None,
     ):
         return cls(
             sampling_rate=output_device.sampling_rate,
             audio_encoding=output_device.audio_encoding,
             api_key=api_key,
             voice_id=voice_id,
+            stability=stability,
+            similarity_boost=similarity_boost,
         )
 
     @classmethod
@@ -153,12 +159,16 @@ class ElevenLabsSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.ELEVEN
         cls,
         api_key: Optional[str] = None,
         voice_id: Optional[str] = None,
+        stability: Optional[float] = None,
+        similarity_boost: Optional[float] = None,
     ):
         return cls(
             sampling_rate=DEFAULT_SAMPLING_RATE,
             audio_encoding=DEFAULT_AUDIO_ENCODING,
             api_key=api_key,
             voice_id=voice_id,
+            stability=stability,
+            similarity_boost=similarity_boost,
         )
 
 

--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -129,12 +129,20 @@ ELEVEN_LABS_ADAM_VOICE_ID = "pNInz6obpgDQGcFmaJgB"
 class ElevenLabsSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.ELEVEN_LABS):
     api_key: Optional[str] = None
     voice_id: Optional[str] = ELEVEN_LABS_ADAM_VOICE_ID
-    stability: Optional[float] = 0.75
-    similarity_boost: Optional[float] = 0.75
+    stability: Optional[float]
+    similarity_boost: Optional[float]
 
     @validator("voice_id")
     def set_name(cls, voice_id):
         return voice_id or ELEVEN_LABS_ADAM_VOICE_ID
+    
+    @validator("similarity_boost", always=True)
+    def stability_and_similarity_boost_check(cls, similarity_boost, values):
+        stability = values.get("stability")
+        if (stability is None) != (similarity_boost is None):
+            raise ValueError("Both stability and similarity_boost must be set or not set.")
+        return similarity_boost
+
 
     @classmethod
     def from_output_device(

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -26,6 +26,8 @@ class ElevenLabsSynthesizer(BaseSynthesizer):
         super().__init__(config)
         self.api_key = config.api_key or getenv("ELEVEN_LABS_API_KEY")
         self.voice_id = config.voice_id or ADAM_VOICE_ID
+        self.stability = config.stability or 0.75
+        self.similarity_boost = config.similarity_boost or 0.75
         self.words_per_minute = 150
 
     def create_speech(
@@ -38,6 +40,10 @@ class ElevenLabsSynthesizer(BaseSynthesizer):
         headers = {"xi-api-key": self.api_key, "voice_id": self.voice_id}
         body = {
             "text": message.text,
+            "voice_settings": {
+                "stability": self.stability,
+                "similarity_boost": self.similarity_boost,
+            },
         }
         response = requests.post(url, headers=headers, json=body, timeout=5)
 

--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -26,8 +26,8 @@ class ElevenLabsSynthesizer(BaseSynthesizer):
         super().__init__(config)
         self.api_key = config.api_key or getenv("ELEVEN_LABS_API_KEY")
         self.voice_id = config.voice_id or ADAM_VOICE_ID
-        self.stability = config.stability or 0.75
-        self.similarity_boost = config.similarity_boost or 0.75
+        self.stability = config.stability
+        self.similarity_boost = config.similarity_boost
         self.words_per_minute = 150
 
     def create_speech(
@@ -38,13 +38,14 @@ class ElevenLabsSynthesizer(BaseSynthesizer):
     ) -> SynthesisResult:
         url = ELEVEN_LABS_BASE_URL + f"text-to-speech/{self.voice_id}"
         headers = {"xi-api-key": self.api_key, "voice_id": self.voice_id}
-        body = {
-            "text": message.text,
-            "voice_settings": {
+        body = {"text": message.text}
+
+        if self.stability is not None and self.similarity_boost is not None:
+            body["voice_settings"] = {
                 "stability": self.stability,
                 "similarity_boost": self.similarity_boost,
-            },
-        }
+            }
+
         response = requests.post(url, headers=headers, json=body, timeout=5)
 
         audio_segment: AudioSegment = AudioSegment.from_mp3(

--- a/vocode/turn_based/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/turn_based/synthesizer/eleven_labs_synthesizer.py
@@ -9,15 +9,27 @@ ELEVEN_LABS_BASE_URL = "https://api.elevenlabs.io/v1/"
 
 
 class ElevenLabsSynthesizer(BaseSynthesizer):
-    def __init__(self, voice_id: str, api_key: Optional[str] = None):
+    def __init__(
+        self, 
+        voice_id: str, 
+        stability: float,
+        similarity_boost: float,
+        api_key: Optional[str] = None,
+    ):
         self.voice_id = voice_id
         self.api_key = getenv("ELEVEN_LABS_API_KEY", api_key)
+        self.stability = stability
+        self.similarity_boost = similarity_boost
 
     def synthesize(self, text: str) -> AudioSegment:
         url = ELEVEN_LABS_BASE_URL + f"text-to-speech/{self.voice_id}"
         headers = {"xi-api-key": self.api_key, "voice_id": self.voice_id}
         body = {
             "text": text,
+            "voice_settings": {
+                "stability": self.stability,
+                "similarity_boost": self.similarity_boost,
+            },
         }
         response = requests.post(url, headers=headers, json=body)
         assert response.ok, response.text

--- a/vocode/turn_based/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/turn_based/synthesizer/eleven_labs_synthesizer.py
@@ -18,19 +18,29 @@ class ElevenLabsSynthesizer(BaseSynthesizer):
     ):
         self.voice_id = voice_id
         self.api_key = getenv("ELEVEN_LABS_API_KEY", api_key)
+        self.validate_stability_and_similarity_boost(stability, similarity_boost)
         self.stability = stability
         self.similarity_boost = similarity_boost
+
+    def validate_stability_and_similarity_boost(
+        self, stability: Optional[float], similarity_boost: Optional[float]
+    ) -> None:
+        if (stability is None) != (similarity_boost is None):
+            raise ValueError("Both stability and similarity_boost must be set or not set.")
 
     def synthesize(self, text: str) -> AudioSegment:
         url = ELEVEN_LABS_BASE_URL + f"text-to-speech/{self.voice_id}"
         headers = {"xi-api-key": self.api_key, "voice_id": self.voice_id}
         body = {
             "text": text,
-            "voice_settings": {
+        }
+
+        if self.stability is not None and self.similarity_boost is not None:
+            body["voice_settings"] = {
                 "stability": self.stability,
                 "similarity_boost": self.similarity_boost,
-            },
-        }
+            }
+
         response = requests.post(url, headers=headers, json=body)
         assert response.ok, response.text
         return AudioSegment.from_mp3(io.BytesIO(response.content))


### PR DESCRIPTION
This is related to issue 18[0]. This change allows Eleven_Labs_Synthesizer to support stability and similarity boost [1]. If the options are not included. By default, these will be 0.75 which is in accordance to the Eleven Labs standard settings [1].

**Testing Instructions**
1. Set-up an inbound server or outbound call with an eleven labs synthesizer. Alternatively, start a streaming conversation with an eleven labs synthesizer.
2. Pass any float between 0.0 and 1.0 to `stability` and `similarity_boost` to `ElevenLabsSynthesizerConfig`
3. Any Synthesized audio will now be changed depending on what you passed in. 

[0] https://github.com/vocodedev/vocode-python/issues/18
[1] https://docs.elevenlabs.io/api-reference/voices-settings-default