### PR TITLE
Fix twilio config specified in environment vars

### DIFF
--- a/vocode/streaming/telephony/conversation/outbound_call.py
+++ b/vocode/streaming/telephony/conversation/outbound_call.py
@@ -60,7 +60,7 @@ class OutboundCall:
             account_sid=getenv("TWILIO_ACCOUNT_SID"),
             auth_token=getenv("TWILIO_AUTH_TOKEN"),
         )
-        self.twilio_client = create_twilio_client(twilio_config)
+        self.twilio_client = create_twilio_client(self.twilio_config)
         self.twilio_sid = None
 
     def create_twilio_call(


### PR DESCRIPTION
When no explicit twilio config is passed to OutboundCall it creates a default. But it doesn't use that default to create the twilio client, which means that reading from the environment does not actually work.