### PR TITLE
[Telephony] Add Twilio config variables to CallConfig

### DIFF
--- a/vocode/streaming/models/telephony.py
+++ b/vocode/streaming/models/telephony.py
@@ -58,3 +58,5 @@ class CallConfig(BaseModel):
     synthesizer_config: SynthesizerConfig
     twilio_config: Optional[TwilioConfig]
     twilio_sid: str
+    twilio_from: str
+    twilio_to: str

--- a/vocode/streaming/telephony/conversation/outbound_call.py
+++ b/vocode/streaming/telephony/conversation/outbound_call.py
@@ -98,16 +98,20 @@ class OutboundCall:
     def start(self):
         self.logger.debug("Starting outbound call")
         self.validate_outbound_call(self.to_phone, self.from_phone)
-        self.twilio_sid = self.create_twilio_call(self.to_phone, self.from_phone)
+        self.twilio_sid = self.create_twilio_call(
+            self.to_phone, self.from_phone)
         call_config = CallConfig(
             transcriber_config=self.transcriber_config,
             agent_config=self.agent_config,
             synthesizer_config=self.synthesizer_config,
             twilio_config=self.twilio_config,
             twilio_sid=self.twilio_sid,
+            twilio_from=self.from_phone,
+            twilio_to=self.to_phone,
         )
         self.config_manager.save_config(self.conversation_id, call_config)
 
     def end(self):
-        response = self.twilio_client.calls(self.twilio_sid).update(status="completed")
+        response = self.twilio_client.calls(
+            self.twilio_sid).update(status="completed")
         return response.status == "completed"

--- a/vocode/streaming/telephony/conversation/zoom_dial_in.py
+++ b/vocode/streaming/telephony/conversation/zoom_dial_in.py
@@ -69,5 +69,7 @@ class ZoomDialIn(OutboundCall):
             synthesizer_config=self.synthesizer_config,
             twilio_config=self.twilio_config,
             twilio_sid=twilio_sid,
+            twilio_from=self.from_phone,
+            twilio_to=digits
         )
         self.config_manager.save_config(self.conversation_id, call_config)

--- a/vocode/streaming/telephony/server/base.py
+++ b/vocode/streaming/telephony/server/base.py
@@ -96,7 +96,8 @@ class TelephonyServer:
                 ),
                 methods=["POST"],
             )
-            logger.info(f"Set up inbound call TwiML at https://{base_url}{config.url}")
+            logger.info(
+                f"Set up inbound call TwiML at https://{base_url}{config.url}")
 
     def create_inbound_route(
         self,
@@ -105,7 +106,11 @@ class TelephonyServer:
         transcriber_config: Optional[TranscriberConfig] = None,
         synthesizer_config: Optional[SynthesizerConfig] = None,
     ):
-        def route(twilio_sid: str = Form(alias="CallSid")) -> Response:
+        def route(
+            twilio_sid: str = Form(alias="CallSid"),
+            twilio_from: str = Form(alias="From"),
+            twilio_to: str = Form(alias="To")
+        ) -> Response:
             call_config = CallConfig(
                 transcriber_config=transcriber_config
                 or DeepgramTranscriberConfig(
@@ -127,6 +132,8 @@ class TelephonyServer:
                     auth_token=getenv("TWILIO_AUTH_TOKEN"),
                 ),
                 twilio_sid=twilio_sid,
+                twilio_from=twilio_from,
+                twilio_to=twilio_to
             )
 
             conversation_id = create_conversation_id()
@@ -141,7 +148,8 @@ class TelephonyServer:
         # TODO validation via twilio_client
         call_config = self.config_manager.get_config(conversation_id)
         if not call_config:
-            raise ValueError(f"Could not find call config for {conversation_id}")
+            raise ValueError(
+                f"Could not find call config for {conversation_id}")
         end_twilio_call(
             create_twilio_client(call_config.twilio_config),
             call_config.twilio_sid,


### PR DESCRIPTION
**Motivation**
For users of Vocode like us [https://bookface.ycombinator.com/company/27492](https://bookface.ycombinator.com/company/27492), we want to save the transcription of the phone call in an external service (aka a DB owned by us). The`BaseAgent` give us the `human_input` and agent response to save but we do not have access to the incoming and outgoing phone numbers to attach to the transcription. 

**Solution**
1. Add `twilio_from` and `twilio_to` to `CallConfig`
2. Set `twilio_from` and `twilio_to` by parsing the `From` and `To` fields of Twilio's post request to our route, also set for the zoom and outbound dialing cases

The `ConfigManager` saves the `CallConfig`. We'll pass the `ConfigManager` to our `BaseAgent` implementation to access the full `CallConfig` which now has the from and to phone numbers