### PR TITLE
Defined class ChatAgent to have a common parent for ChatAnthropicAgent and ChatGPTAgent.

### DIFF
--- a/vocode/streaming/agent/chat_agent.py
+++ b/vocode/streaming/agent/chat_agent.py
@@ -1,0 +1,45 @@
+import logging
+from typing import Optional, Tuple, Generator
+
+from vocode.streaming.models.agent import AgentConfig
+from vocode.streaming.agent.base_agent import BaseAgent
+
+from langchain.schema import ChatMessage, AIMessage
+from langchain.memory import ConversationBufferMemory
+
+
+class ChatAgent(BaseAgent):
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        logger: Optional[logging.Logger] = None,
+    ):
+        super().__init__(agent_config)
+        self.logger = logger or logging.getLogger(__name__)
+        self.logger.setLevel(logging.DEBUG)
+        self.memory = ConversationBufferMemory(return_messages=True)
+
+    def respond(
+        self,
+        human_input,
+        is_interrupt: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> Tuple[str, bool]:
+        raise NotImplementedError
+
+    def generate_response(
+        self,
+        human_input,
+        is_interrupt: bool = False,
+        conversation_id: Optional[str] = None,
+    ) -> Generator[str, None, None]:
+        raise NotImplementedError
+
+    def update_last_bot_message_on_cut_off(self, message: str):
+        for memory_message in self.memory.chat_memory.messages[::-1]:
+            if (
+                isinstance(memory_message, ChatMessage)
+                and memory_message.role == "assistant"
+            ) or isinstance(memory_message, AIMessage):
+                memory_message.content = message
+                return

--- a/vocode/streaming/agent/utils.py
+++ b/vocode/streaming/agent/utils.py
@@ -4,8 +4,10 @@ SENTENCE_ENDINGS = [".", "!", "?"]
 
 
 def stream_llm_response(
-    gen, get_text=lambda choice: choice.get("text"), sentence_endings=SENTENCE_ENDINGS
+    gen, get_text=lambda choice: choice.get("text"), sentence_endings=None
 ) -> Generator:
+    if sentence_endings is None:
+        sentence_endings = SENTENCE_ENDINGS
     buffer = ""
     for response in gen:
         choices = response.get("choices", [])
@@ -23,3 +25,16 @@ def stream_llm_response(
             buffer = ""
     if buffer.strip():
         yield buffer
+
+
+def find_last_punctuation(buffer: str):
+    indices = [buffer.rfind(ending) for ending in SENTENCE_ENDINGS]
+    return indices and max(indices)
+
+
+def get_sentence_from_buffer(buffer: str):
+    last_punctuation = find_last_punctuation(buffer)
+    if last_punctuation:
+        return buffer[: last_punctuation + 1], buffer[last_punctuation + 1 :]
+    else:
+        return None, None


### PR DESCRIPTION
Tries to resolve #75 defining a common class ChatAgent for ChatAnthropicAgent and ChatGPTAgent.
The class extends **BaseAgent** setting the **logger** and the **ConversationBufferMemory** in the init:

https://github.com/MarioAlessandroNapoli/vocode-python/blob/1bb1baa4ed00293ef90f1a03c4608535b6e9dc2d/vocode/streaming/agent/chat_agent.py#L17-L20

It also emplements the common function **update_last_bot_message_on_cut_off** 

https://github.com/MarioAlessandroNapoli/vocode-python/blob/1bb1baa4ed00293ef90f1a03c4608535b6e9dc2d/vocode/streaming/agent/chat_agent.py#L38-L45

leaving **respond** and **generate_response** to further implementations in the child classes.

I also did some light Refactoring of ChatAnthropicAgent and ChatGPTAgent to clean up imports, remove redundant code and move some static functions () to the utils file:

https://github.com/MarioAlessandroNapoli/vocode-python/blob/1bb1baa4ed00293ef90f1a03c4608535b6e9dc2d/vocode/streaming/agent/utils.py#L30-L40

Leaving less methods in ChatAnthropicAgent that now just call the external util:

https://github.com/MarioAlessandroNapoli/vocode-python/blob/1bb1baa4ed00293ef90f1a03c4608535b6e9dc2d/vocode/streaming/agent/anthropic_agent.py#L6

https://github.com/MarioAlessandroNapoli/vocode-python/blob/1bb1baa4ed00293ef90f1a03c4608535b6e9dc2d/vocode/streaming/agent/anthropic_agent.py#L98