### PR TITLE
add pyngrok to telephony app

### DIFF
--- a/apps/telephony_app/main.py
+++ b/apps/telephony_app/main.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from fastapi import FastAPI
-
+from pyngrok import ngrok
 from vocode.streaming.telephony.config_manager.redis_config_manager import (
     RedisConfigManager,
 )
@@ -20,6 +20,10 @@ logger.setLevel(logging.DEBUG)
 config_manager = RedisConfigManager()
 
 BASE_URL = os.getenv("BASE_URL")
+
+if not BASE_URL:
+    http_tunnel = ngrok.connect(3000)
+    BASE_URL = http_tunnel.public_url.replace("https://", "")
 
 telephony_server = TelephonyServer(
     base_url=BASE_URL,

--- a/apps/telephony_app/requirements.txt
+++ b/apps/telephony_app/requirements.txt
@@ -1,3 +1,4 @@
 vocode==0.1.105
 redis
 twilio
+pyngrok==6.0.0


### PR DESCRIPTION
Add pyngrok http tunnel to telephony app only if Base URL is not set.

The port is hardcoded to 3000. There should be a global variable to define the port. I'll leave it like that given it's hardcoded in the rest of the project. 

[Issue](https://github.com/vocodedev/vocode-python/issues/77)