### PR TITLE
[BREAKING] TranscriptCompleteEvent.transcript type

### DIFF
--- a/apps/langchain_agent/telephony_app.py
+++ b/apps/langchain_agent/telephony_app.py
@@ -28,7 +28,7 @@ class EventsManager(events_manager.EventsManager):
             transcript_complete_event = typing.cast(TranscriptCompleteEvent, event)
             add_transcript(
                 transcript_complete_event.conversation_id,
-                transcript_complete_event.transcript,
+                transcript_complete_event.transcript.to_string(),
             )
 
 

--- a/docs/events-manager.mdx
+++ b/docs/events-manager.mdx
@@ -80,7 +80,7 @@ class CustomEventsManager(events_manager.EventsManager):
             transcript_complete_event = typing.cast(TranscriptCompleteEvent, event)
             add_transcript(
                 transcript_complete_event.conversation_id,
-                transcript_complete_event.transcript,
+                transcript_complete_event.transcript.to_string(),
             )
 
 events_manager_instance = CustomEventsManager()

--- a/vocode/streaming/models/events.py
+++ b/vocode/streaming/models/events.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from vocode.streaming.models.model import TypedModel
-
+from vocode.streaming.utils import Transcript
 
 class Sender(str, Enum):
     HUMAN = "human"
@@ -38,4 +38,4 @@ class PhoneCallEndedEvent(Event, type=EventType.PHONE_CALL_ENDED):
 
 
 class TranscriptCompleteEvent(Event, type=EventType.TRANSCRIPT_COMPLETE):
-    transcript: str
+    transcript: Transcript

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -564,7 +564,7 @@ class StreamingConversation:
         self.mark_terminated()
         self.events_manager.publish_event(
             TranscriptCompleteEvent(
-                conversation_id=self.id, transcript=self.transcript.to_string()
+                conversation_id=self.id, transcript=self.transcript
             )
         )
         if self.current_agent_span:


### PR DESCRIPTION
Change the type of the `transcript` field from `str` to `Transcript`.  This gives the consumers of the event the flexibility to get the transcript in whatever format they prefer: string without timestamps, string with timestamps, or possibly other formats too.

Discussed here:
https://discord.com/channels/1079125925163180093/1079125925830078466/1105966476407603273