### PR TITLE
[BREAKING] TranscriptCompleteEvent.transcript type (take 2)

### DIFF
--- a/apps/langchain_agent/call_transcript_utils.py
+++ b/apps/langchain_agent/call_transcript_utils.py
@@ -4,12 +4,13 @@ from typing import Optional
 CALL_TRANSCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "call_transcripts")
 
 
-def add_transcript(conversation_id: str, transcript: str) -> None:
+def add_transcript(conversation_id: str, transcript: dict) -> None:
     transcript_path = os.path.join(
         CALL_TRANSCRIPTS_DIR, "{}.txt".format(conversation_id)
     )
     with open(transcript_path, "a") as f:
-        f.write(transcript)
+        for message in transcript["messages"]:
+            f.write("{}: {}\n".format(message["sender"], message["text"]))
 
 
 def get_transcript(conversation_id: str) -> Optional[str]:

--- a/apps/langchain_agent/telephony_app.py
+++ b/apps/langchain_agent/telephony_app.py
@@ -28,7 +28,7 @@ class EventsManager(events_manager.EventsManager):
             transcript_complete_event = typing.cast(TranscriptCompleteEvent, event)
             add_transcript(
                 transcript_complete_event.conversation_id,
-                transcript_complete_event.transcript,
+                transcript_complete_event.transcript.to_string(),
             )
 
 

--- a/apps/langchain_agent/telephony_app.py
+++ b/apps/langchain_agent/telephony_app.py
@@ -28,7 +28,7 @@ class EventsManager(events_manager.EventsManager):
             transcript_complete_event = typing.cast(TranscriptCompleteEvent, event)
             add_transcript(
                 transcript_complete_event.conversation_id,
-                transcript_complete_event.transcript.to_string(),
+                transcript_complete_event.transcript,
             )
 
 

--- a/docs/events-manager.mdx
+++ b/docs/events-manager.mdx
@@ -80,7 +80,7 @@ class CustomEventsManager(events_manager.EventsManager):
             transcript_complete_event = typing.cast(TranscriptCompleteEvent, event)
             add_transcript(
                 transcript_complete_event.conversation_id,
-                transcript_complete_event.transcript,
+                transcript_complete_event.transcript.to_string(),
             )
 
 events_manager_instance = CustomEventsManager()

--- a/vocode/streaming/models/events.py
+++ b/vocode/streaming/models/events.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from vocode.streaming.models.model import TypedModel
 
-
 class Sender(str, Enum):
     HUMAN = "human"
     BOT = "bot"
@@ -38,4 +37,5 @@ class PhoneCallEndedEvent(Event, type=EventType.PHONE_CALL_ENDED):
 
 
 class TranscriptCompleteEvent(Event, type=EventType.TRANSCRIPT_COMPLETE):
-    transcript: str
+    from vocode.streaming.utils.transcript import Transcript
+    transcript: Transcript

--- a/vocode/streaming/models/events.py
+++ b/vocode/streaming/models/events.py
@@ -37,5 +37,4 @@ class PhoneCallEndedEvent(Event, type=EventType.PHONE_CALL_ENDED):
 
 
 class TranscriptCompleteEvent(Event, type=EventType.TRANSCRIPT_COMPLETE):
-    from vocode.streaming.utils.transcript import Transcript
-    transcript: Transcript
+    transcript: dict

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -664,7 +664,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.mark_terminated()
         self.events_manager.publish_event(
             TranscriptCompleteEvent(
-                conversation_id=self.id, transcript=self.transcript
+                conversation_id=self.id, transcript=self.transcript.to_dict()
             )
         )
         if self.check_for_idle_task:

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -664,7 +664,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.mark_terminated()
         self.events_manager.publish_event(
             TranscriptCompleteEvent(
-                conversation_id=self.id, transcript=self.transcript.to_string()
+                conversation_id=self.id, transcript=self.transcript
             )
         )
         if self.check_for_idle_task:

--- a/vocode/streaming/utils/transcript.py
+++ b/vocode/streaming/utils/transcript.py
@@ -29,17 +29,17 @@ class Transcript(BaseModel):
         )
 
     def to_dict(self) -> dict:
-        result = {
-            "start_time": self.start_time,
-            "messages": [],
-        }
+        messages = []
         for message in self.messages:
-            result["messages"].append({
+            messages.append({
                 'timestamp': message.timestamp,
                 'text': message.text,
                 'sender': message.sender.value,
             })
-        return result
+        return {
+            "start_time": self.start_time,
+            "messages": messages,
+        }
 
     def add_message(
         self,

--- a/vocode/streaming/utils/transcript.py
+++ b/vocode/streaming/utils/transcript.py
@@ -28,6 +28,19 @@ class Transcript(BaseModel):
             for message in self.messages
         )
 
+    def to_dict(self) -> dict:
+        result = {
+            "start_time": self.start_time,
+            "messages": [],
+        }
+        for message in self.messages:
+            result["messages"].append({
+                'timestamp': message.timestamp,
+                'text': message.text,
+                'sender': message.sender.value,
+            })
+        return result
+
     def add_message(
         self,
         text: str,


### PR DESCRIPTION
Change the type of the transcript field from `str` to `dict`. This gives the consumers of the event the flexibility to get the transcript with as much or as little detail as they want (e.g. with or without timestamps).

Discussed here:
https://discord.com/channels/1079125925163180093/1079125925830078466/1105966476407603273

This is attempt number two.  The first attempt was to define the field as type `Transcript`, but that resulted in a circular reference.  Ajay suggested going with a dict instead.  https://github.com/vocodedev/vocode-python/commit/fc509d47d76f0ba2ae636c2e0d58acded3420f60
