### PR TITLE
Add a mobile_only parameter for OutboundCall

### DIFF
--- a/vocode/streaming/telephony/conversation/outbound_call.py
+++ b/vocode/streaming/telephony/conversation/outbound_call.py
@@ -38,10 +38,12 @@ class OutboundCall:
         synthesizer_config: Optional[SynthesizerConfig] = None,
         conversation_id: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
+        mobile_only: bool = True,
     ):
         self.base_url = base_url
         self.to_phone = to_phone
         self.from_phone = from_phone
+        self.mobile_only = mobile_only
         self.config_manager = config_manager
         self.agent_config = agent_config
         self.transcriber_config = transcriber_config or DeepgramTranscriberConfig(
@@ -98,7 +100,11 @@ class OutboundCall:
 
     def start(self):
         self.logger.debug("Starting outbound call")
-        self.validate_outbound_call(self.to_phone, self.from_phone)
+        self.validate_outbound_call(
+            to_phone=self.to_phone,
+            from_phone=self.from_phone,
+            mobile_only=self.mobile_only,
+        )
         self.twilio_sid = self.create_twilio_call(
             to_phone=self.to_phone,
             from_phone=self.from_phone,


### PR DESCRIPTION
This allows you to disable the mobile-only validation that is currently on by default.

Discussed here:
https://discord.com/channels/1079125925163180093/1091639833635602452/threads/1108515875641901168