### PR TITLE
Use streaming endpoint for ElevenLabs and Add Model_id parameter (Multi-Languge support)

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -106,6 +106,7 @@ class ElevenLabsSynthesizerConfig(
     stability: Optional[float]
     similarity_boost: Optional[float]
     optimize_streaming_latency: Optional[int]
+    model_id: Optional[str] = "eleven_monolingual_v1"
 
     @validator("voice_id")
     def set_name(cls, voice_id):


### PR DESCRIPTION
In response to issue #80, adding support for ElevenLab's streaming endpoint to hopefully increase the speed of the synthesis, although I personally didn't find that big of a difference (1.3s average using Opentelemetry tracing)

Also added a parameter for model_id, since ElevenLabs has multi-language support using the "eleven_multilingual_v1" model. 

 