### PR TITLE
Agent Workers

### DIFF
--- a/playground/streaming/agent/chat.py
+++ b/playground/streaming/agent/chat.py
@@ -1,4 +1,11 @@
+import asyncio
+import typing
+from dotenv import load_dotenv
+
+load_dotenv()
+
 from vocode.streaming.agent import *
+from vocode.streaming.agent.base_agent import AgentResponseMessage, AgentResponseType
 from vocode.streaming.models.agent import (
     AgentConfig,
     ChatAnthropicAgentConfig,
@@ -8,34 +15,67 @@ from vocode.streaming.models.agent import (
     LLMAgentConfig,
     RESTfulUserImplementedAgentConfig,
 )
+from vocode.streaming.models.message import BaseMessage
+from vocode.streaming.transcriber.base_transcriber import Transcription
 from vocode.streaming.utils import create_conversation_id
 
 
-if __name__ == "__main__":
-    import asyncio
-    from dotenv import load_dotenv
+async def run_agent(agent: BaseAgent):
+    ended = False
 
-    load_dotenv()
+    async def receiver():
+        nonlocal ended
+        while not ended:
+            try:
+                event = await agent.get_output_queue().get()
+                response = event.payload
+                if response.type == AgentResponseType.FILLER_AUDIO:
+                    print("Would have sent filler audio")
+                elif response.type == AgentResponseType.STOP:
+                    print("Agent returned stop")
+                    ended = True
+                    break
+                elif response.type == AgentResponseType.MESSAGE:
+                    print(
+                        "\nAI: ",
+                        typing.cast(AgentResponseMessage, response).message.text,
+                    )
+            except asyncio.CancelledError:
+                break
 
-    async def run_agent(agent: BaseAgent, generate_responses: bool):
+    async def sender():
         conversation_id = create_conversation_id()
-        while True:
-            if generate_responses:
-                stream = agent.generate_response(
-                    input("Human: "), conversation_id=conversation_id
+        while not ended:
+            try:
+                message = await asyncio.get_event_loop().run_in_executor(
+                    None, input, "Human: "
                 )
-                async for sentence in stream:
-                    print("AI:", sentence)
-            else:
-                response, _ = await agent.respond(
-                    input("Human: "), conversation_id=conversation_id
+                agent.consume_nonblocking(
+                    agent.interruptible_event_factory.create(
+                        (Transcription(message, 1.0, True), conversation_id)
+                    )
                 )
-                print("AI:", response)
+            except asyncio.CancelledError:
+                break
 
-    # replace with the agent you want to test
+    await asyncio.gather(receiver(), sender())
+
+
+async def main():
     agent = ChatGPTAgent(
         ChatGPTAgentConfig(
             prompt_preamble="The assistant is having a pleasant conversation about life.",
+            end_conversation_on_goodbye=True,
         )
     )
-    asyncio.run(run_agent(agent=agent, generate_responses=True))
+    agent.start()
+    task = asyncio.create_task(run_agent(agent))
+    try:
+        await task
+    except KeyboardInterrupt:
+        task.cancel()
+        agent.terminate()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/playground/streaming/agent/chat.py
+++ b/playground/streaming/agent/chat.py
@@ -5,7 +5,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from vocode.streaming.agent import *
-from vocode.streaming.agent.base_agent import AgentResponseMessage, AgentResponseType
+from vocode.streaming.agent.base_agent import (
+    AgentInput,
+    AgentResponseMessage,
+    AgentResponseType,
+)
 from vocode.streaming.models.agent import (
     AgentConfig,
     ChatAnthropicAgentConfig,
@@ -18,10 +22,50 @@ from vocode.streaming.models.agent import (
 from vocode.streaming.models.message import BaseMessage
 from vocode.streaming.transcriber.base_transcriber import Transcription
 from vocode.streaming.utils import create_conversation_id
+import curses
 
 
-async def run_agent(agent: BaseAgent):
+def clear_current_line(win):
+    y, x = win.getyx()  # Get current position
+    height, width = win.getmaxyx()  # Get window size
+    win.addstr(y, 0, " " * (width - 1))  # Write spaces over the entire line
+    win.move(y, 0)  # Move the cursor back to the start of the line
+
+
+def get_user_input(win, human_idx):
+    curses.noecho()
+    message = ""
+    while True:
+        ch = win.getch()
+        if ch in [curses.KEY_ENTER, 10, 13]:  # Enter key pressed
+            break
+        elif ch in [curses.KEY_BACKSPACE, 127]:  # Backspace key pressed
+            message = message[:-1]
+            clear_current_line(win)
+            win.addstr(human_idx, 0, "Human: " + message)
+        else:
+            message += chr(ch)
+            win.addstr(chr(ch))
+        win.refresh()
+    return message
+
+
+async def run_agent(agent: BaseAgent, stdscr):
     ended = False
+
+    # Determine the size and position of each window
+    height, width = stdscr.getmaxyx()
+    half_width = width // 2
+
+    # Create two windows for AI and human
+    ai_win = stdscr.subwin(
+        height, half_width - 1, 0, 0
+    )  # Starts at (0,0) and occupies the left half
+    human_win = stdscr.subwin(
+        height, half_width, 0, half_width
+    )  # Starts at (0, half_width) and occupies the right half
+
+    human_idx = 0
 
     async def receiver():
         nonlocal ended
@@ -30,38 +74,69 @@ async def run_agent(agent: BaseAgent):
                 event = await agent.get_output_queue().get()
                 response = event.payload
                 if response.type == AgentResponseType.FILLER_AUDIO:
-                    print("Would have sent filler audio")
+                    ai_win.addstr("Would have sent filler audio\n")
+                    ai_win.refresh()
                 elif response.type == AgentResponseType.STOP:
-                    print("Agent returned stop")
+                    ai_win.addstr("Agent returned stop\n")
+                    ai_win.refresh()
                     ended = True
                     break
                 elif response.type == AgentResponseType.MESSAGE:
-                    print(
-                        "\nAI: ",
-                        typing.cast(AgentResponseMessage, response).message.text,
+                    ai_win.addstr(
+                        "AI: "
+                        + typing.cast(AgentResponseMessage, response).message.text
+                        + "\n",
                     )
+                    ai_win.refresh()
+
+                    human_win.addstr(human_idx, 0, "Human: ")
+                    human_win.refresh()
             except asyncio.CancelledError:
                 break
 
     async def sender():
+        nonlocal human_idx
         conversation_id = create_conversation_id()
+        human_win.addstr("Human: ")
+        human_win.refresh()
         while not ended:
             try:
+                curses.echo()
                 message = await asyncio.get_event_loop().run_in_executor(
-                    None, input, "Human: "
+                    None, lambda: get_user_input(human_win, human_idx)
                 )
+                curses.noecho()
                 agent.consume_nonblocking(
                     agent.interruptible_event_factory.create(
-                        (Transcription(message, 1.0, True), conversation_id)
+                        AgentInput(
+                            transcription=Transcription(
+                                message=message, confidence=1.0, is_final=True
+                            ),
+                            conversation_id=conversation_id,
+                        )
                     )
                 )
+                human_win.refresh()
             except asyncio.CancelledError:
                 break
+            human_idx += 1
 
     await asyncio.gather(receiver(), sender())
 
 
-async def main():
+def start_curses(stdscr):
+    stdscr.clear()
+    stdscr.refresh()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    loop.run_until_complete(agent_main(stdscr))
+    loop.close()
+
+
+async def agent_main(stdscr):
+    # Replace with your agent!
     agent = ChatGPTAgent(
         ChatGPTAgentConfig(
             prompt_preamble="The assistant is having a pleasant conversation about life.",
@@ -69,13 +144,12 @@ async def main():
         )
     )
     agent.start()
-    task = asyncio.create_task(run_agent(agent))
+
     try:
-        await task
+        await run_agent(agent, stdscr)
     except KeyboardInterrupt:
-        task.cancel()
         agent.terminate()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    curses.wrapper(start_curses)

--- a/playground/streaming/synthesizer/synthesize.py
+++ b/playground/streaming/synthesizer/synthesize.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
                 speech_length_seconds = seconds_per_chunk * (
                     len(chunk_result.chunk) / chunk_size
                 )
-                output_device.send_nonblocking(chunk_result.chunk)
+                output_device.consume_nonblocking(chunk_result.chunk)
                 end_time = time.time()
                 await asyncio.sleep(
                     max(

--- a/tests/streaming/fixtures/output_device.py
+++ b/tests/streaming/fixtures/output_device.py
@@ -2,5 +2,5 @@ from vocode.streaming.output_device.base_output_device import BaseOutputDevice
 
 
 class SilentOutputDevice(BaseOutputDevice):
-    def send_nonblocking(self, chunk: bytes):
+    def consume_nonblocking(self, chunk: bytes):
         pass

--- a/tests/streaming/fixtures/transcriber.py
+++ b/tests/streaming/fixtures/transcriber.py
@@ -19,7 +19,7 @@ class TestAsyncTranscriber(BaseAsyncTranscriber):
         while True:
             try:
                 self.output_queue.put_nowait(
-                    Transcription("test", confidence=1, is_final=True)
+                    Transcription(message="test", confidence=1, is_final=True)
                 )
                 await asyncio.sleep(1)
             except asyncio.CancelledError:

--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -3,19 +3,26 @@ from enum import Enum
 import logging
 import random
 from typing import AsyncGenerator, Generator, Generic, Optional, Tuple, TypeVar, Union
+from opentelemetry import trace
+from opentelemetry.trace import Span
 
 from vocode.streaming.models.agent import (
     AgentConfig,
     ChatGPTAgentConfig,
     LLMAgentConfig,
 )
+from vocode.streaming.models.message import BaseMessage
 from vocode.streaming.models.model import TypedModel
 from vocode.streaming.transcriber.base_transcriber import Transcription
+from vocode.streaming.utils.goodbye_model import GoodbyeModel
 from vocode.streaming.utils.worker import (
     InterruptibleEvent,
     InterruptibleEventFactory,
     InterruptibleWorker,
 )
+
+tracer = trace.get_tracer(__name__)
+AGENT_TRACE_NAME = "agent"
 
 
 class AgentResponseType(str, Enum):
@@ -30,7 +37,7 @@ class AgentResponse(TypedModel, type=AgentResponseType.BASE.value):
 
 
 class AgentResponseMessage(TypedModel, type=AgentResponseType.MESSAGE.value):
-    message: str
+    message: BaseMessage
     is_interruptible: bool = True
 
 
@@ -70,22 +77,140 @@ class BaseAgent(AbstractAgent[AgentConfigType], InterruptibleWorker):
     def __init__(
         self,
         agent_config: AgentConfigType,
-        input_queue: asyncio.Queue[InterruptibleEvent[Transcription]],
-        output_queue: asyncio.Queue[InterruptibleEvent[AgentResponse]],
-        interruptible_event_factory: InterruptibleEventFactory,
+        interruptible_event_factory: InterruptibleEventFactory = InterruptibleEventFactory(),
+        logger: Optional[logging.Logger] = None,
     ):
+        self.input_queue: asyncio.Queue[
+            InterruptibleEvent[Tuple[Transcription, str]]
+        ] = asyncio.Queue()
+        self.output_queue: asyncio.Queue[
+            InterruptibleEvent[AgentResponse]
+        ] = asyncio.Queue()
         AbstractAgent.__init__(self, agent_config=agent_config)
         InterruptibleWorker.__init__(
             self,
-            input_queue=input_queue,
-            output_queue=output_queue,
+            input_queue=self.input_queue,
+            output_queue=self.output_queue,
             interruptible_event_factory=interruptible_event_factory,
         )
+        self.logger = logger or logging.getLogger(__name__)
+        self.goodbye_model = None
+        if self.agent_config.end_conversation_on_goodbye:
+            self.goodbye_model = GoodbyeModel()
+            self.goodbye_model_initialize_task = asyncio.create_task(
+                self.goodbye_model.initialize_embeddings()
+            )
+
+    def start(self):
+        super().start()
+        if self.agent_config.initial_message is not None:
+            self.produce_interruptible_event_nonblocking(
+                AgentResponseMessage(message=self.agent_config.initial_message),
+                is_interruptible=False,
+            )
+
+    def set_interruptible_event_factory(self, factory: InterruptibleEventFactory):
+        self.interruptible_event_factory = factory
+
+    def get_input_queue(
+        self,
+    ) -> asyncio.Queue[InterruptibleEvent[Tuple[Transcription, str]]]:
+        return self.input_queue
+
+    def get_output_queue(self) -> asyncio.Queue[InterruptibleEvent[AgentResponse]]:
+        return self.output_queue
+
+    def create_goodbye_detection_task(self, message: str) -> asyncio.Task:
+        assert self.goodbye_model is not None
+        return asyncio.create_task(self.goodbye_model.is_goodbye(message))
 
 
-class RespondAgent(BaseAgent):
-    async def process(self, item: InterruptibleEvent[Transcription]) -> None:
-        return await super().process(item)
+class RespondAgent(BaseAgent[AgentConfigType]):
+    async def handle_generate_response(
+        self, transcription: Transcription, conversation_id: str
+    ) -> bool:
+        agent_span = tracer.start_span(
+            AGENT_TRACE_NAME, {"generate_response": True}  # type: ignore
+        )
+        responses = self.generate_response(
+            transcription.message,
+            is_interrupt=transcription.is_interrupt,
+            conversation_id=conversation_id,
+        )
+        is_first_response = True
+        async for response in responses:
+            if is_first_response:
+                agent_span.end()
+            self.produce_interruptible_event_nonblocking(
+                AgentResponseMessage(message=BaseMessage(text=response)),
+                is_interruptible=self.agent_config.allow_agent_to_be_cut_off,
+            )
+        # TODO: implement should_stop for generate_responses
+        return False
+
+    async def handle_respond(
+        self, transcription: Transcription, conversation_id: str
+    ) -> bool:
+        try:
+            with tracer.start_as_current_span(
+                AGENT_TRACE_NAME, {"generate_response": False}  # type: ignore
+            ):
+                response, should_stop = await self.respond(
+                    transcription.message,
+                    is_interrupt=transcription.is_interrupt,
+                    conversation_id=conversation_id,
+                )
+        except Exception as e:
+            self.logger.error(f"Error while generating response: {e}", exc_info=True)
+            response = None
+            return True
+        if response:
+            self.produce_interruptible_event_nonblocking(
+                AgentResponseMessage(message=BaseMessage(text=response)),
+                is_interruptible=self.agent_config.allow_agent_to_be_cut_off,
+            )
+            return should_stop
+        else:
+            self.logger.debug("No response generated")
+        return False
+
+    async def process(self, item: InterruptibleEvent[Tuple[Transcription, str]]):
+        try:
+            transcription, conversation_id = item.payload
+            goodbye_detected_task = None
+            if self.agent_config.end_conversation_on_goodbye:
+                goodbye_detected_task = self.create_goodbye_detection_task(
+                    transcription.message
+                )
+            if self.agent_config.send_filler_audio:
+                self.produce_interruptible_event_nonblocking(AgentResponseFillerAudio())
+            self.logger.debug("Responding to transcription")
+            should_stop = False
+            if self.agent_config.generate_responses:
+                should_stop = await self.handle_generate_response(
+                    transcription, conversation_id
+                )
+            else:
+                should_stop = await self.handle_respond(transcription, conversation_id)
+            if should_stop:
+                self.logger.debug("Agent requested to stop")
+                self.produce_interruptible_event_nonblocking(AgentResponseStop())
+                return
+            if goodbye_detected_task:
+                try:
+                    goodbye_detected = await asyncio.wait_for(
+                        goodbye_detected_task, 0.1
+                    )
+                    if goodbye_detected:
+                        self.logger.debug("Goodbye detected, ending conversation")
+                        self.produce_interruptible_event_nonblocking(
+                            AgentResponseStop()
+                        )
+                        return
+                except asyncio.TimeoutError:
+                    self.logger.debug("Goodbye detection timed out")
+        except asyncio.CancelledError:
+            pass
 
     async def respond(
         self,

--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from enum import Enum
 import logging

--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -1,26 +1,91 @@
+import asyncio
+from enum import Enum
 import logging
 import random
-from typing import AsyncGenerator, Generator, Generic, Optional, Tuple, TypeVar
+from typing import AsyncGenerator, Generator, Generic, Optional, Tuple, TypeVar, Union
+
 from vocode.streaming.models.agent import (
     AgentConfig,
     ChatGPTAgentConfig,
     LLMAgentConfig,
 )
+from vocode.streaming.models.model import TypedModel
+from vocode.streaming.transcriber.base_transcriber import Transcription
+from vocode.streaming.utils.worker import (
+    InterruptibleEvent,
+    InterruptibleEventFactory,
+    InterruptibleWorker,
+)
+
+
+class AgentResponseType(str, Enum):
+    BASE = "agent_response_base"
+    MESSAGE = "agent_response_message"
+    STOP = "agent_response_stop"
+    FILLER_AUDIO = "agent_response_filler_audio"
+
+
+class AgentResponse(TypedModel, type=AgentResponseType.BASE.value):
+    pass
+
+
+class AgentResponseMessage(TypedModel, type=AgentResponseType.MESSAGE.value):
+    message: str
+    is_interruptible: bool = True
+
+
+class AgentResponseStop(TypedModel, type=AgentResponseType.STOP.value):
+    pass
+
+
+class AgentResponseFillerAudio(TypedModel, type=AgentResponseType.FILLER_AUDIO.value):
+    pass
+
 
 AgentConfigType = TypeVar("AgentConfigType", bound=AgentConfig)
 
 
-class BaseAgent(Generic[AgentConfigType]):
-    def __init__(
-        self, agent_config: AgentConfigType, logger: Optional[logging.Logger] = None
-    ):
+class AbstractAgent(Generic[AgentConfigType]):
+    def __init__(self, agent_config: AgentConfigType):
         self.agent_config = agent_config
 
     def get_agent_config(self) -> AgentConfig:
         return self.agent_config
 
-    def start(self):
+    def update_last_bot_message_on_cut_off(self, message: str):
+        """Updates the last bot message in the conversation history when the human cuts off the bot's response."""
         pass
+
+    def get_cut_off_response(self) -> str:
+        assert isinstance(self.agent_config, LLMAgentConfig) or isinstance(
+            self.agent_config, ChatGPTAgentConfig
+        )
+        assert self.agent_config.cut_off_response is not None
+        on_cut_off_messages = self.agent_config.cut_off_response.messages
+        assert len(on_cut_off_messages) > 0
+        return random.choice(on_cut_off_messages).text
+
+
+class BaseAgent(AbstractAgent[AgentConfigType], InterruptibleWorker):
+    def __init__(
+        self,
+        agent_config: AgentConfigType,
+        input_queue: asyncio.Queue[InterruptibleEvent[Transcription]],
+        output_queue: asyncio.Queue[InterruptibleEvent[AgentResponse]],
+        interruptible_event_factory: InterruptibleEventFactory,
+    ):
+        AbstractAgent.__init__(self, agent_config=agent_config)
+        InterruptibleWorker.__init__(
+            self,
+            input_queue=input_queue,
+            output_queue=output_queue,
+            interruptible_event_factory=interruptible_event_factory,
+        )
+
+
+class RespondAgent(BaseAgent):
+    async def process(self, item: InterruptibleEvent[Transcription]) -> None:
+        return await super().process(item)
 
     async def respond(
         self,
@@ -36,21 +101,4 @@ class BaseAgent(Generic[AgentConfigType]):
         conversation_id: str,
         is_interrupt: bool = False,
     ) -> AsyncGenerator[str, None]:
-        """Returns a generator that yields a sentence at a time."""
         raise NotImplementedError
-
-    def update_last_bot_message_on_cut_off(self, message: str):
-        """Updates the last bot message in the conversation history when the human cuts off the bot's response."""
-        pass
-
-    def get_cut_off_response(self) -> str:
-        assert isinstance(self.agent_config, LLMAgentConfig) or isinstance(
-            self.agent_config, ChatGPTAgentConfig
-        )
-        assert self.agent_config.cut_off_response is not None
-        on_cut_off_messages = self.agent_config.cut_off_response.messages
-        assert len(on_cut_off_messages) > 0
-        return random.choice(on_cut_off_messages).text
-
-    def terminate(self):
-        pass

--- a/vocode/streaming/agent/chat_agent.py
+++ b/vocode/streaming/agent/chat_agent.py
@@ -6,7 +6,7 @@ from vocode.streaming.models.agent import (
     ChatAnthropicAgentConfig,
     ChatGPTAgentConfig,
 )
-from vocode.streaming.agent.base_agent import BaseAgent
+from vocode.streaming.agent.base_agent import BaseAgent, RespondAgent
 
 from langchain.schema import ChatMessage, AIMessage
 from langchain.memory import ConversationBufferMemory
@@ -17,7 +17,7 @@ ChatAgentConfigType = TypeVar(
 )
 
 
-class ChatAgent(BaseAgent[ChatAgentConfigType]):
+class ChatAgent(RespondAgent[ChatAgentConfigType]):
     def __init__(
         self,
         agent_config: ChatAgentConfigType,

--- a/vocode/streaming/agent/echo_agent.py
+++ b/vocode/streaming/agent/echo_agent.py
@@ -1,9 +1,9 @@
 from typing import AsyncGenerator, Generator, Optional, Tuple
-from vocode.streaming.agent.base_agent import BaseAgent
+from vocode.streaming.agent.base_agent import BaseAgent, RespondAgent
 from vocode.streaming.models.agent import EchoAgentConfig
 
 
-class EchoAgent(BaseAgent[EchoAgentConfig]):
+class EchoAgent(RespondAgent[EchoAgentConfig]):
     async def respond(
         self,
         human_input,

--- a/vocode/streaming/agent/gpt4all_agent.py
+++ b/vocode/streaming/agent/gpt4all_agent.py
@@ -1,10 +1,10 @@
 from typing import Optional, Tuple
-from vocode.streaming.agent.base_agent import BaseAgent
+from vocode.streaming.agent.base_agent import BaseAgent, RespondAgent
 from vocode.streaming.models.agent import GPT4AllAgentConfig
 from vocode.turn_based.agent.gpt4all_agent import GPT4AllAgent as TurnBasedGPT4AllAgent
 
 
-class GPT4AllAgent(BaseAgent):
+class GPT4AllAgent(RespondAgent[GPT4AllAgentConfig]):
     def __init__(self, agent_config: GPT4AllAgentConfig):
         super().__init__(agent_config=agent_config)
         self.turn_based_agent = TurnBasedGPT4AllAgent(

--- a/vocode/streaming/agent/llm_agent.py
+++ b/vocode/streaming/agent/llm_agent.py
@@ -8,12 +8,12 @@ import logging
 import openai
 from vocode import getenv
 
-from vocode.streaming.agent.base_agent import BaseAgent
+from vocode.streaming.agent.base_agent import BaseAgent, RespondAgent
 from vocode.streaming.agent.utils import stream_openai_response_async
 from vocode.streaming.models.agent import LLMAgentConfig
 
 
-class LLMAgent(BaseAgent[LLMAgentConfig]):
+class LLMAgent(RespondAgent[LLMAgentConfig]):
     SENTENCE_ENDINGS = [".", "!", "?"]
 
     DEFAULT_PROMPT_TEMPLATE = "{history}\nHuman: {human_input}\nAI:"

--- a/vocode/streaming/agent/restful_user_implemented_agent.py
+++ b/vocode/streaming/agent/restful_user_implemented_agent.py
@@ -1,4 +1,4 @@
-from .base_agent import BaseAgent
+from .base_agent import BaseAgent, RespondAgent
 from ..models.agent import (
     RESTfulUserImplementedAgentConfig,
     RESTfulAgentInput,
@@ -12,7 +12,7 @@ import logging
 import aiohttp
 
 
-class RESTfulUserImplementedAgent(BaseAgent):
+class RESTfulUserImplementedAgent(RespondAgent[RESTfulUserImplementedAgentConfig]):
     def __init__(
         self,
         agent_config: RESTfulUserImplementedAgentConfig,
@@ -23,7 +23,6 @@ class RESTfulUserImplementedAgent(BaseAgent):
             raise NotImplementedError(
                 "Use the WebSocket user implemented agent to stream responses"
             )
-        self.agent_config = agent_config
         self.logger = logger or logging.getLogger(__name__)
 
     async def respond(

--- a/vocode/streaming/hosted_streaming_conversation.py
+++ b/vocode/streaming/hosted_streaming_conversation.py
@@ -60,7 +60,7 @@ class HostedStreamingConversation:
             while self.active:
                 try:
                     audio = self.output_audio_queue.get(timeout=5)
-                    self.output_device.send_nonblocking(audio)
+                    self.output_device.consume_nonblocking(audio)
                 except queue.Empty:
                     continue
 

--- a/vocode/streaming/output_device/base_output_device.py
+++ b/vocode/streaming/output_device/base_output_device.py
@@ -9,7 +9,7 @@ class BaseOutputDevice:
     def start(self):
         pass
 
-    def send_nonblocking(self, chunk: bytes):
+    def consume_nonblocking(self, chunk: bytes):
         raise NotImplemented
 
     def maybe_send_mark_nonblocking(self, message):

--- a/vocode/streaming/output_device/blocking_speaker_output.py
+++ b/vocode/streaming/output_device/blocking_speaker_output.py
@@ -45,8 +45,8 @@ class BlockingSpeakerOutput(BaseOutputDevice, ThreadAsyncWorker):
             except queue.Empty:
                 continue
 
-    def send_nonblocking(self, chunk):
-        ThreadAsyncWorker.send_nonblocking(self, chunk)
+    def consume_nonblocking(self, chunk):
+        ThreadAsyncWorker.consume_nonblocking(self, chunk)
 
     def terminate(self):
         self._ended = True

--- a/vocode/streaming/output_device/speaker_output.py
+++ b/vocode/streaming/output_device/speaker_output.py
@@ -40,7 +40,7 @@ class SpeakerOutput(BaseOutputDevice):
         data = self.queue.get()
         outdata[:, 0] = data
 
-    def send_nonblocking(self, chunk):
+    def consume_nonblocking(self, chunk):
         chunk_arr = np.frombuffer(chunk, dtype=np.int16)
         for i in range(0, chunk_arr.shape[0], self.blocksize):
             block = np.zeros(self.blocksize, dtype=np.int16)

--- a/vocode/streaming/output_device/twilio_output_device.py
+++ b/vocode/streaming/output_device/twilio_output_device.py
@@ -32,7 +32,7 @@ class TwilioOutputDevice(BaseOutputDevice):
             message = await self.queue.get()
             await self.ws.send_text(message)
 
-    def send_nonblocking(self, chunk: bytes):
+    def consume_nonblocking(self, chunk: bytes):
         twilio_message = {
             "event": "media",
             "streamSid": self.stream_sid,

--- a/vocode/streaming/output_device/websocket_output_device.py
+++ b/vocode/streaming/output_device/websocket_output_device.py
@@ -25,7 +25,7 @@ class WebsocketOutputDevice(BaseOutputDevice):
             message = await self.queue.get()
             await self.ws.send_text(message)
 
-    def send_nonblocking(self, chunk: bytes):
+    def consume_nonblocking(self, chunk: bytes):
         if self.active:
             audio_message = AudioMessage.from_bytes(chunk)
             self.queue.put_nowait(audio_message.json())

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -56,9 +56,6 @@ from vocode.streaming.utils.worker import (
     InterruptibleWorker,
 )
 
-tracer = trace.get_tracer(__name__)
-AGENT_TRACE_NAME = "agent"
-
 OutputDeviceType = TypeVar("OutputDeviceType", bound=BaseOutputDevice)
 
 

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -467,6 +467,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                         num_interrupts += 1
             except queue.Empty:
                 break
+        self.agent.cancel_current_task()
         self.agent_responses_worker.cancel_current_task()
         return num_interrupts > 0
 

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -123,8 +123,10 @@ class StreamingConversation(Generic[OutputDeviceType]):
             )
             self.conversation.is_human_speaking = not transcription.is_final
             if transcription.is_final:
-                event = self.interruptible_event_factory.create(transcription)
-                self.output_queue.put_nowait((event, self.conversation.id))
+                event = self.interruptible_event_factory.create(
+                    (transcription, self.conversation.id)
+                )
+                self.output_queue.put_nowait(event)
 
     class FillerAudioWorker(InterruptibleWorker):
         """

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -123,6 +123,11 @@ class StreamingConversation(Generic[OutputDeviceType]):
             )
             self.conversation.is_human_speaking = not transcription.is_final
             if transcription.is_final:
+                self.conversation.transcript.add_human_message(
+                    text=transcription.message,
+                    events_manager=self.conversation.events_manager,
+                    conversation_id=self.conversation.id,
+                )
                 event = self.interruptible_event_factory.create(
                     (transcription, self.conversation.id)
                 )

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -23,10 +23,7 @@ from vocode.streaming.utils.events_manager import EventsManager
 from vocode.streaming.utils.goodbye_model import GoodbyeModel
 from vocode.streaming.utils.transcript import Transcript
 
-from vocode.streaming.models.agent import (
-    FillerAudioConfig,
-    FILLER_AUDIO_DEFAULT_SILENCE_THRESHOLD_SECONDS,
-)
+from vocode.streaming.models.agent import FillerAudioConfig
 from vocode.streaming.models.synthesizer import (
     SentimentConfig,
 )
@@ -36,6 +33,7 @@ from vocode.streaming.constants import (
     ALLOWED_IDLE_TIME,
 )
 from vocode.streaming.agent.base_agent import (
+    AgentInput,
     AgentResponse,
     AgentResponseMessage,
     AgentResponseType,
@@ -85,7 +83,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         def __init__(
             self,
             input_queue: asyncio.Queue[Transcription],
-            output_queue: asyncio.Queue[InterruptibleEvent[Tuple[Transcription, str]]],
+            output_queue: asyncio.Queue[InterruptibleEvent[AgentInput]],
             conversation: "StreamingConversation",
             interruptible_event_factory: InterruptibleEventFactory,
         ):
@@ -129,7 +127,10 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     conversation_id=self.conversation.id,
                 )
                 event = self.interruptible_event_factory.create(
-                    (transcription, self.conversation.id)
+                    AgentInput(
+                        transcription=transcription,
+                        conversation_id=self.conversation.id,
+                    )
                 )
                 self.output_queue.put_nowait(event)
 

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -115,7 +115,11 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
                     )
                     if "text" in data and data["text"]:
                         self.output_queue.put_nowait(
-                            Transcription(data["text"], data["confidence"], is_final)
+                            Transcription(
+                                message=data["text"],
+                                confidence=data["confidence"],
+                                is_final=is_final,
+                            )
                         )
 
             await asyncio.gather(sender(ws), receiver(ws))

--- a/vocode/streaming/transcriber/azure_transcriber.py
+++ b/vocode/streaming/transcriber/azure_transcriber.py
@@ -63,12 +63,12 @@ class AzureTranscriber(BaseThreadAsyncTranscriber[AzureTranscriberConfig]):
 
     def recognized_sentence_final(self, evt):
         self.output_janus_queue.sync_q.put_nowait(
-            Transcription(evt.result.text, 1.0, True)
+            Transcription(message=evt.result.text, confidence=1.0, is_final=True)
         )
 
     def recognized_sentence_stream(self, evt):
         self.output_janus_queue.sync_q.put_nowait(
-            Transcription(evt.result.text, 1.0, False)
+            Transcription(message=evt.result.text, confidence=1.0, is_final=False)
         )
 
     def _run_loop(self):

--- a/vocode/streaming/transcriber/base_transcriber.py
+++ b/vocode/streaming/transcriber/base_transcriber.py
@@ -69,9 +69,9 @@ class BaseAsyncTranscriber(AbstractTranscriber[TranscriberConfigType], AsyncWork
 
     def send_audio(self, chunk):
         if not self.is_muted:
-            self.send_nonblocking(chunk)
+            self.consume_nonblocking(chunk)
         else:
-            self.send_nonblocking(self.create_silent_chunk(len(chunk)))
+            self.consume_nonblocking(self.create_silent_chunk(len(chunk)))
 
     def terminate(self):
         AsyncWorker.terminate(self)
@@ -94,9 +94,9 @@ class BaseThreadAsyncTranscriber(
 
     def send_audio(self, chunk):
         if not self.is_muted:
-            self.send_nonblocking(chunk)
+            self.consume_nonblocking(chunk)
         else:
-            self.send_nonblocking(self.create_silent_chunk(len(chunk)))
+            self.consume_nonblocking(self.create_silent_chunk(len(chunk)))
 
     def terminate(self):
         ThreadAsyncWorker.terminate(self)

--- a/vocode/streaming/transcriber/base_transcriber.py
+++ b/vocode/streaming/transcriber/base_transcriber.py
@@ -4,23 +4,17 @@ import asyncio
 import audioop
 from typing import Generic, TypeVar, Union
 from vocode.streaming.models.audio_encoding import AudioEncoding
+from vocode.streaming.models.model import BaseModel
 
 from vocode.streaming.models.transcriber import TranscriberConfig
 from vocode.streaming.utils.worker import AsyncWorker, ThreadAsyncWorker
 
 
-class Transcription:
-    def __init__(
-        self,
-        message: str,
-        confidence: float,
-        is_final: bool,
-        is_interrupt: bool = False,
-    ):
-        self.message = message
-        self.confidence = confidence
-        self.is_final = is_final
-        self.is_interrupt = is_interrupt
+class Transcription(BaseModel):
+    message: str
+    confidence: float
+    is_final: bool
+    is_interrupt: bool = False
 
     def __str__(self):
         return f"Transcription({self.message}, {self.confidence}, {self.is_final})"

--- a/vocode/streaming/transcriber/deepgram_transcriber.py
+++ b/vocode/streaming/transcriber/deepgram_transcriber.py
@@ -187,16 +187,18 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
 
                     if speech_final:
                         self.output_queue.put_nowait(
-                            Transcription(buffer, confidence, True)
+                            Transcription(
+                                message=buffer, confidence=confidence, is_final=True
+                            )
                         )
                         buffer = ""
                         time_silent = 0
                     elif top_choice["transcript"] and confidence > 0.0:
                         self.output_queue.put_nowait(
                             Transcription(
-                                buffer,
-                                confidence,
-                                False,
+                                message=buffer,
+                                confidence=confidence,
+                                is_final=False,
                             )
                         )
                         time_silent = self.calculate_time_silent(data)

--- a/vocode/streaming/transcriber/google_transcriber.py
+++ b/vocode/streaming/transcriber/google_transcriber.py
@@ -100,7 +100,9 @@ class GoogleTranscriber(BaseThreadAsyncTranscriber[GoogleTranscriberConfig]):
         confidence = top_choice.confidence
 
         self.output_janus_queue.sync_q.put_nowait(
-            Transcription(message, confidence, result.is_final)
+            Transcription(
+                message=message, confidence=confidence, is_final=result.is_final
+            )
         )
 
     def generator(self):

--- a/vocode/streaming/transcriber/rev_ai_transcriber.py
+++ b/vocode/streaming/transcriber/rev_ai_transcriber.py
@@ -123,15 +123,17 @@ class RevAITranscriber(BaseAsyncTranscriber[RevAITranscriberConfig]):
                     confidence = 1.0
                     if is_done:
                         self.output_queue.put_nowait(
-                            Transcription(buffer, confidence, True)
+                            Transcription(
+                                message=buffer, confidence=confidence, is_final=True
+                            )
                         )
                         buffer = ""
                     else:
                         self.output_queue.put_nowait(
                             Transcription(
-                                buffer,
-                                confidence,
-                                False,
+                                message=buffer,
+                                confidence=confidence,
+                                is_final=False,
                             )
                         )
 

--- a/vocode/streaming/transcriber/whisper_cpp_transcriber.py
+++ b/vocode/streaming/transcriber/whisper_cpp_transcriber.py
@@ -81,7 +81,9 @@ class WhisperCPPTranscriber(BaseThreadAsyncTranscriber[WhisperCPPTranscriberConf
                 )
                 in_memory_wav, audio_buffer = self.create_new_buffer()
                 self.output_queue.put_nowait(
-                    Transcription(message_buffer, confidence, is_final)
+                    Transcription(
+                        message=message_buffer, confidence=confidence, is_final=is_final
+                    )
                 )
                 if is_final:
                     message_buffer = ""

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -24,8 +24,11 @@ class AsyncWorker:
         self.worker_task = asyncio.create_task(self._run_loop())
         return self.worker_task
 
-    def send_nonblocking(self, item):
+    def consume_nonblocking(self, item):
         self.input_queue.put_nowait(item)
+
+    def produce_nonblocking(self, item):
+        self.output_queue.put_nowait(item)
 
     async def _run_loop(self):
         raise NotImplementedError
@@ -126,17 +129,30 @@ class InterruptibleEvent(Generic[Payload]):
         return self.is_interruptible and self.interruption_event.is_set()
 
 
+class InterruptibleEventFactory:
+    def create(self, payload: Any, is_interruptible: bool = True) -> InterruptibleEvent:
+        return InterruptibleEvent(payload, is_interruptible=is_interruptible)
+
+
 class InterruptibleWorker(AsyncWorker):
     def __init__(
         self,
         input_queue: asyncio.Queue[InterruptibleEvent],
         output_queue: asyncio.Queue = asyncio.Queue(),
+        interruptible_event_factory: InterruptibleEventFactory = InterruptibleEventFactory(),
         max_concurrency=2,
     ) -> None:
         super().__init__(input_queue, output_queue)
         self.input_queue = input_queue
         self.max_concurrency = max_concurrency
+        self.interruptible_event_factory = interruptible_event_factory
         self.current_task = None
+
+    def produce_interruptible_event_nonblocking(
+        self, item: Any, is_interruptible: bool = True
+    ):
+        interruptible_event = self.interruptible_event_factory.create(item)
+        return super().produce_nonblocking(interruptible_event)
 
     async def _run_loop(self):
         # TODO Implement concurrency with max_nb_of_thread

--- a/vocode/streaming/utils/worker.py
+++ b/vocode/streaming/utils/worker.py
@@ -147,6 +147,7 @@ class InterruptibleWorker(AsyncWorker):
         self.max_concurrency = max_concurrency
         self.interruptible_event_factory = interruptible_event_factory
         self.current_task = None
+        self.interruptible_event = None
 
     def produce_interruptible_event_nonblocking(
         self, item: Any, is_interruptible: bool = True


### PR DESCRIPTION
Refactors `BaseAgent` as an `InterruptibleWorker` and collapses all agent related code from `StreamingConversation` into the worker, including:
- goodbye detection
- deciding to send filler audio

Existing agent implementations now implement `RespondAgent`, which essentially ports most of the logic in `FinalTranscriptionsWorker`

Now, agents can be implemented with full control over the input and output queues.