### PR TITLE
fix readme for new create_streaming_microphone_input_and_speaker_output function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import signal
 
 import vocode
 from vocode.streaming.streaming_conversation import StreamingConversation
-from vocode.helpers import create_microphone_input_and_speaker_output
+from vocode.helpers import create_streaming_microphone_input_and_speaker_output
 from vocode.streaming.models.transcriber import (
     DeepgramTranscriberConfig,
     PunctuationEndpointingConfig,
@@ -86,7 +86,7 @@ vocode.setenv(
 
 
 async def main():
-    microphone_input, speaker_output = create_microphone_input_and_speaker_output(
+    microphone_input, speaker_output = create_streaming_microphone_input_and_speaker_output(
         streaming=True, use_default_devices=False
     )
 
@@ -136,7 +136,7 @@ import signal
 import vocode
 from vocode.streaming.hosted_streaming_conversation import HostedStreamingConversation
 from vocode.streaming.streaming_conversation import StreamingConversation
-from vocode.helpers import create_microphone_input_and_speaker_output
+from vocode.helpers import create_streaming_microphone_input_and_speaker_output
 from vocode.streaming.models.transcriber import (
     DeepgramTranscriberConfig,
     PunctuationEndpointingConfig,
@@ -145,11 +145,11 @@ from vocode.streaming.models.agent import ChatGPTAgentConfig
 from vocode.streaming.models.message import BaseMessage
 from vocode.streaming.models.synthesizer import AzureSynthesizerConfig
 
-vocode.api_key = "<your API key>"
+vocode.api_key = "<your server API key>"
 
 
 if __name__ == "__main__":
-    microphone_input, speaker_output = create_microphone_input_and_speaker_output(
+    microphone_input, speaker_output = create_streaming_microphone_input_and_speaker_output(
         streaming=True, use_default_devices=False
     )
 


### PR DESCRIPTION
Hi! Looks like the function "create_microphone_input_and_speaker_output" was renamed to "create_streaming_microphone_input_and_speaker_output" a few days ago. Just fixing this in the README, since it didn't initially work when I tried out vocode.

Also added the word "server" to the API key template variable, will hopefully make it more clear to choose a "server" key in the Vocode cloud platform.   