### PR TITLE
[WIP] Play DTMF tones using Twilio `<Play>`

### DIFF
--- a/vocode/streaming/models/telephony.py
+++ b/vocode/streaming/models/telephony.py
@@ -4,7 +4,7 @@ from vocode.streaming.models.model import BaseModel
 from vocode.streaming.models.agent import AgentConfig
 from vocode.streaming.models.synthesizer import SynthesizerConfig
 from vocode.streaming.models.transcriber import TranscriberConfig
-
+from vocode.streaming.models.transcript import Transcript
 
 class TwilioConfig(BaseModel):
     account_sid: str
@@ -61,3 +61,4 @@ class CallConfig(BaseModel):
     twilio_sid: str
     twilio_from: Optional[str]
     twilio_to: Optional[str]
+    transcript: Optional[Transcript]

--- a/vocode/streaming/models/transcript.py
+++ b/vocode/streaming/models/transcript.py
@@ -39,7 +39,7 @@ class Action(EventLog):
 
 
 class Transcript(BaseModel):
-    event_logs: List[EventLog] = []
+    event_logs: List[Union[Message, Action]] = []
     start_time: float = Field(default_factory=time.time)
     events_manager: Optional[EventsManager] = None
 

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -565,11 +565,12 @@ class StreamingConversation(Generic[OutputDeviceType]):
     def mark_terminated(self):
         self.active = False
 
-    def terminate(self):
+    def terminate(self, conversation_ended=True):
         self.mark_terminated()
-        self.events_manager.publish_event(
-            TranscriptCompleteEvent(conversation_id=self.id, transcript=self.transcript)
-        )
+        if conversation_ended:
+            self.events_manager.publish_event(
+                TranscriptCompleteEvent(conversation_id=self.id, transcript=self.transcript)
+            )
         if self.check_for_idle_task:
             self.logger.debug("Terminating check_for_idle Task")
             self.check_for_idle_task.cancel()

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -321,6 +321,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         per_chunk_allowance_seconds: float = PER_CHUNK_ALLOWANCE_SECONDS,
         events_manager: Optional[EventsManager] = None,
         logger: Optional[logging.Logger] = None,
+        transcript: Optional[Transcript] = None,
     ):
         self.id = conversation_id or create_conversation_id()
         self.logger = logger or logging.getLogger(__name__)
@@ -373,7 +374,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.events_manager = events_manager or EventsManager()
         self.events_task: Optional[asyncio.Task] = None
         self.per_chunk_allowance_seconds = per_chunk_allowance_seconds
-        self.transcript = Transcript()
+        self.transcript = transcript or Transcript()
         self.transcript.attach_events_manager(self.events_manager)
         self.bot_sentiment = None
         if self.agent.get_agent_config().track_bot_sentiment:

--- a/vocode/streaming/telephony/conversation/call.py
+++ b/vocode/streaming/telephony/conversation/call.py
@@ -119,7 +119,7 @@ class Call(StreamingConversation):
 
         self.twilio_call = self.twilio_client.calls(self.twilio_sid).fetch()
 
-        if self.twilio_call.answered_by in ("machine_start", "fax"):
+        if self.twilio_call is not None and self.twilio_call.answered_by in ("machine_start", "fax"):
             self.logger.info(f"Call answered by {self.twilio_call.answered_by}")
             self.twilio_call.update(status="completed")
         else:
@@ -205,4 +205,7 @@ class Call(StreamingConversation):
             base_url=self.base_url,
             digits=dtmf_key)
         self.logger.debug(f"twiml: {twiml}")
-        self.twilio_call.update(twiml=twiml)
+        if self.twilio_call is None:
+            self.logger.error("twilio_call is None")
+        else:
+            self.twilio_call.update(twiml=twiml)

--- a/vocode/streaming/telephony/conversation/call.py
+++ b/vocode/streaming/telephony/conversation/call.py
@@ -181,7 +181,11 @@ class Call(StreamingConversation):
         super().mark_terminated()
         if self.playing_dtmf:
             self.logger.debug("We are playing DTMF so we won't terminate the call.  Instead, saving call config.")
+            # Save the transcript on the call config before we store it
             self.call_config.transcript = self.transcript
+            # But clear out the events_manager because it may not be JSON serializable
+            self.call_config.transcript.events_manager = None
+            # Now store it, so we can continue with the same transcript when we get the next websocket connection
             self.config_manager.save_config(conversation_id=self.id, config=self.call_config)
         else:
             self.logger.debug("Ending call")

--- a/vocode/streaming/telephony/server/base.py
+++ b/vocode/streaming/telephony/server/base.py
@@ -135,6 +135,7 @@ class TelephonyServer:
                 twilio_sid=twilio_sid,
                 twilio_from=twilio_from,
                 twilio_to=twilio_to,
+                transcript=None,
             )
 
             conversation_id = create_conversation_id()

--- a/vocode/streaming/telephony/server/router/calls.py
+++ b/vocode/streaming/telephony/server/router/calls.py
@@ -39,36 +39,27 @@ class CallsRouter(BaseRouter):
         self.router = APIRouter()
         self.router.websocket("/connect_call/{id}")(self.connect_call)
 
-        self.calls: Dict[str, Call] = {}
-
     async def connect_call(self, websocket: WebSocket, id: str):
         await websocket.accept()
         self.logger.debug("Phone WS connection opened for chat {}".format(id))
 
-        call: Call
+        call_config = self.config_manager.get_config(id)
+        if not call_config:
+            raise HTTPException(status_code=400, detail="No active phone call")
 
-        if id in self.calls:
-            self.logger.debug("Connecting new websocket for existing Call with id {}".format(id))
-            call = self.calls[id]
-            await call.attach_ws_and_start(websocket, initial_connection=False)
-        else:
-            call_config = self.config_manager.get_config(id)
-            if not call_config:
-                raise HTTPException(status_code=400, detail="No active phone call")
+        call = Call.from_call_config(
+            base_url=self.base_url,
+            call_config=call_config,
+            config_manager=self.config_manager,
+            conversation_id=id,
+            transcriber_factory=self.transcriber_factory,
+            agent_factory=self.agent_factory,
+            synthesizer_factory=self.synthesizer_factory,
+            events_manager=self.events_manager,
+            logger=self.logger,
+        )
 
-            call = Call.from_call_config(
-                base_url=self.base_url,
-                call_config=call_config,
-                config_manager=self.config_manager,
-                conversation_id=id,
-                transcriber_factory=self.transcriber_factory,
-                agent_factory=self.agent_factory,
-                synthesizer_factory=self.synthesizer_factory,
-                events_manager=self.events_manager,
-                logger=self.logger,
-            )
-            self.calls[id] = call
-            await call.attach_ws_and_start(websocket)
+        await call.attach_ws_and_start(websocket)
 
         self.logger.debug("Phone WS connection closed for chat {}".format(id))
 

--- a/vocode/streaming/telephony/server/router/calls.py
+++ b/vocode/streaming/telephony/server/router/calls.py
@@ -39,11 +39,13 @@ class CallsRouter(BaseRouter):
         self.router = APIRouter()
         self.router.websocket("/connect_call/{id}")(self.connect_call)
 
-        self.calls = {}
+        self.calls: dict[str, Call] = {}
 
     async def connect_call(self, websocket: WebSocket, id: str):
         await websocket.accept()
         self.logger.debug("Phone WS connection opened for chat {}".format(id))
+
+        call: Call
 
         if id in self.calls:
             self.logger.debug("Connecting new websocket for existing Call with id {}".format(id))
@@ -54,7 +56,7 @@ class CallsRouter(BaseRouter):
             if not call_config:
                 raise HTTPException(status_code=400, detail="No active phone call")
 
-            call: Call = Call.from_call_config(
+            call = Call.from_call_config(
                 base_url=self.base_url,
                 call_config=call_config,
                 config_manager=self.config_manager,

--- a/vocode/streaming/telephony/server/router/calls.py
+++ b/vocode/streaming/telephony/server/router/calls.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 import logging
 
 from fastapi import APIRouter, HTTPException, WebSocket
@@ -39,7 +39,7 @@ class CallsRouter(BaseRouter):
         self.router = APIRouter()
         self.router.websocket("/connect_call/{id}")(self.connect_call)
 
-        self.calls: dict[str, Call] = {}
+        self.calls: Dict[str, Call] = {}
 
     async def connect_call(self, websocket: WebSocket, id: str):
         await websocket.accept()

--- a/vocode/streaming/telephony/templater.py
+++ b/vocode/streaming/telephony/templater.py
@@ -18,3 +18,19 @@ class Templater:
             self.render_template("connect_call.xml", base_url=base_url, id=call_id),
             media_type="application/xml",
         )
+
+    def get_play_digits_and_connect_call_twiml(self, call_id: str, base_url: str, digits: str):
+        # Note that this returns just the raw TWIML, not a Response object.
+        return self.render_template(
+            "play_digits_and_connect_call.xml",
+            base_url=base_url,
+            id=call_id,
+            digits=digits,
+        )
+
+    def get_play_digits_twiml(self, digits: str):
+        # Note that this returns just the raw TWIML, not a Response object.
+        return self.render_template(
+            "play_digits.xml",
+            digits=digits,
+        )

--- a/vocode/streaming/telephony/templates/play_digits.xml
+++ b/vocode/streaming/telephony/templates/play_digits.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Play digits="{{ digits }}"></Play>
+</Response>

--- a/vocode/streaming/telephony/templates/play_digits_and_connect_call.xml
+++ b/vocode/streaming/telephony/templates/play_digits_and_connect_call.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Play digits="{{ digits }}"></Play>
+  <Connect>
+    <Stream url="wss://{{ base_url }}/connect_call/{{ id }}" />
+  </Connect>
+</Response>


### PR DESCRIPTION
We have this ongoing effort to make the vocode bot capable of "walking phone trees" -- to listen to menu options, decide what to press, and then "press a button" (play DTMF tone).

Discussions here:
https://discord.com/channels/1079125925163180093/1110400160950927370/1110400163392016474

Our first attempt was to have wav files for each of those tones and to play the wav through the stream, as we might with typing-noise.wav.  Unfortunately, this doesn't work.  Twilio has confirmed that they don't support playing DTMF tones through the stream.

So, the new approach is to instead rely on Twilio's built-in `<Play>` verb.  You can pass it the `digits` to play.  This PR attempts to add that capability.

STATUS
This PR now works!  I successfully had a vocode outbound call to a test IVR that I set up on Twilio, and the bot managed to navigate the 2-step phone tree.

REMAINING ISSUES
The PR fully tears down the `Call` each time we play a tone, and then sets up a brand new `Call` when the websocket is re-established after the tone.  The consequence is that you get multiple call-started / call-ended / transcript-complete events.  And each transcript-complete event only gives you a part of the overall transcript.