### PR TITLE
Avoid division by zero

### DIFF
--- a/vocode/streaming/synthesizer/base_synthesizer.py
+++ b/vocode/streaming/synthesizer/base_synthesizer.py
@@ -158,11 +158,11 @@ class BaseSynthesizer(Generic[SynthesizerConfigType]):
         estimated_output_seconds = (
             size_of_output / self.synthesizer_config.sampling_rate
         )
-        if len(message.text) == 0:
-            return 1
-        else:
-            estimated_output_seconds_per_char = estimated_output_seconds / len(message.text)
-            return message.text[: int(seconds / estimated_output_seconds_per_char)]
+        if not message.text:
+            return message.text
+
+        estimated_output_seconds_per_char = estimated_output_seconds / len(message.text)
+        return message.text[: int(seconds / estimated_output_seconds_per_char)]
 
     def get_message_cutoff_from_voice_speed(
         self, message: BaseMessage, seconds: int, words_per_minute: int

--- a/vocode/streaming/synthesizer/base_synthesizer.py
+++ b/vocode/streaming/synthesizer/base_synthesizer.py
@@ -158,8 +158,11 @@ class BaseSynthesizer(Generic[SynthesizerConfigType]):
         estimated_output_seconds = (
             size_of_output / self.synthesizer_config.sampling_rate
         )
-        estimated_output_seconds_per_char = estimated_output_seconds / len(message.text)
-        return message.text[: int(seconds / estimated_output_seconds_per_char)]
+        if len(message.text) == 0:
+            return 1
+        else:
+            estimated_output_seconds_per_char = estimated_output_seconds / len(message.text)
+            return message.text[: int(seconds / estimated_output_seconds_per_char)]
 
     def get_message_cutoff_from_voice_speed(
         self, message: BaseMessage, seconds: int, words_per_minute: int


### PR DESCRIPTION
I saw the following in one of my tests:
```
Traceback (most recent call last):
  File "/Users/shahafabileah/work/vocode/vocode-python/vocode/streaming/utils/worker.py", line 167, in _run_loop
    await self.current_task
  File "/Users/shahafabileah/work/vocode/vocode-python/vocode/streaming/streaming_conversation.py", line 284, in process
    message_sent, cut_off = await self.conversation.send_speech_to_output(
  File "/Users/shahafabileah/work/vocode/vocode-python/vocode/streaming/streaming_conversation.py", line 515, in send_speech_to_output
    message_sent = f"{synthesis_result.get_message_up_to(seconds)}-"
  File "/Users/shahafabileah/work/vocode/vocode-python/vocode/streaming/synthesizer/base_synthesizer.py", line 212, in <lambda>
    lambda seconds: self.get_message_cutoff_from_total_response_length(
  File "/Users/shahafabileah/work/vocode/vocode-python/vocode/streaming/synthesizer/base_synthesizer.py", line 161, in get_message_cutoff_from_total_response_length
    estimated_output_seconds_per_char = estimated_output_seconds / len(message.text)
ZeroDivisionError: float division by zero
```

I haven't dug deeper to understand why the message is empty, and I don't know if 1 is a good fallback value.