### PR TITLE
Fix so websocket output starts with method, not on init

### DIFF
--- a/vocode/streaming/output_device/websocket_output_device.py
+++ b/vocode/streaming/output_device/websocket_output_device.py
@@ -13,8 +13,11 @@ class WebsocketOutputDevice(BaseOutputDevice):
     ):
         super().__init__(sampling_rate, audio_encoding)
         self.ws = ws
-        self.active = True
+        self.active = False
         self.queue: asyncio.Queue[str] = asyncio.Queue()
+
+    def start(self):
+        self.active = True
         self.process_task = asyncio.create_task(self.process())
 
     def mark_closed(self):


### PR DESCRIPTION
I suggest that no activity should be started in the constructor but should follow the pattern of starting when start() has been called.