### PR TITLE
Fix that sender is hardcoded to human

### DIFF
--- a/vocode/streaming/models/transcript.py
+++ b/vocode/streaming/models/transcript.py
@@ -40,7 +40,7 @@ class Transcript(BaseModel):
         events_manager.publish_event(
             TranscriptEvent(
                 text=text,
-                sender=Sender.HUMAN,
+                sender=sender,
                 timestamp=time.time(),
                 conversation_id=conversation_id,
             )


### PR DESCRIPTION
This appears to be a bug, sender is hardcoded to human but should depend on what we get into add_message, right?