### PR TITLE
Always support sentiment

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -403,7 +403,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.agent.attach_transcript(self.transcript)
         if mark_ready:
             await mark_ready()
-        if self.synthesizer.get_synthesizer_config().sentiment_config:
+        if hasattr(self, "sentiment_config"):
             self.update_bot_sentiment()
         self.active = True
         if self.synthesizer.get_synthesizer_config().sentiment_config:

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -403,10 +403,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.agent.attach_transcript(self.transcript)
         if mark_ready:
             await mark_ready()
+        self.active = True
         if hasattr(self, "sentiment_config"):
             self.update_bot_sentiment()
-        self.active = True
-        if self.synthesizer.get_synthesizer_config().sentiment_config:
             self.track_bot_sentiment_task = asyncio.create_task(
                 self.track_bot_sentiment()
             )


### PR DESCRIPTION
In the `__init__` we have the following code:

```
if self.agent.get_agent_config().track_bot_sentiment:
            self.sentiment_config = (
                self.synthesizer.get_synthesizer_config().sentiment_config
            )
            if not self.sentiment_config:
                self.sentiment_config = SentimentConfig()
            self.bot_sentiment_analyser = BotSentimentAnalyser(
                emotions=self.sentiment_config.emotions
            )
```

This seems to me that we can get a SentimentConfig even if the synthesizer has no sentiment_config, e.g. it's enough that we have track_bot_sentiment on agent. But in the start method, we only start tracking sentiment if the synthesizer has the sentiment_config. So I propose a change that it will start tracking if `self.sentiment_config` exists. This allows us to track sentiment regardless if the synthesizer is configured for it or not.