### PR TITLE
Fixed bug in python quickstart docs

### DIFF
--- a/docs/python-quickstart.mdx
+++ b/docs/python-quickstart.mdx
@@ -57,7 +57,7 @@ import signal
 
 import vocode
 from vocode.streaming.streaming_conversation import StreamingConversation
-from vocode.helpers import create_microphone_input_and_speaker_output
+from vocode.helpers import create_streaming_microphone_input_and_speaker_output
 from vocode.streaming.models.transcriber import (
     DeepgramTranscriberConfig,
     PunctuationEndpointingConfig,
@@ -79,8 +79,8 @@ vocode.setenv(
 
 
 async def main():
-    microphone_input, speaker_output = create_microphone_input_and_speaker_output(
-        streaming=True, use_default_devices=False
+    microphone_input, speaker_output = create_streaming_microphone_input_and_speaker_output(
+        use_default_devices=True
     )
 
     conversation = StreamingConversation(


### PR DESCRIPTION
The current docs use create_microphone_input_and_speaker_output which is outdated, changed to streaming.

Name change from create_microphone_input_and_speaker_output to create_streaming_microphone_input_and_speaker_output , 

Fixes #162 