### PR TITLE
Add `FileOutputDevice`

### DIFF
--- a/vocode/streaming/output_device/file_output_device.py
+++ b/vocode/streaming/output_device/file_output_device.py
@@ -1,0 +1,35 @@
+import wave
+import numpy as np
+
+from .base_output_device import BaseOutputDevice
+from vocode.streaming.models.audio_encoding import AudioEncoding
+
+
+class FileOutputDevice(BaseOutputDevice):
+    DEFAULT_SAMPLING_RATE = 44100
+
+    def __init__(
+        self,
+        file_path: str,
+        sampling_rate: int = DEFAULT_SAMPLING_RATE,
+        audio_encoding: AudioEncoding = AudioEncoding.LINEAR16,
+    ):
+        super().__init__(sampling_rate, audio_encoding)
+        self.blocksize = self.sampling_rate
+        wav = wave.open(file_path, "wb")
+        wav.setnchannels(1)  # Mono channel
+        wav.setsampwidth(2)  # 16-bit samples
+        wav.setframerate(sampling_rate)
+        self.wav = wav
+
+    def consume_nonblocking(self, chunk):
+        chunk_arr = np.frombuffer(chunk, dtype=np.int16)
+        for i in range(0, chunk_arr.shape[0], self.blocksize):
+            block = np.zeros(self.blocksize, dtype=np.int16)
+            size = min(self.blocksize, chunk_arr.shape[0] - i)
+            block[:size] = chunk_arr[i : i + size]
+            # write the chunk to the wave file
+            self.wav.writeframes(block)
+
+    def terminate(self):
+        self.wav.close()


### PR DESCRIPTION
Creates a `FileOutputDevice` similar to the `MicrophoneOutput` device. `FileOutputDevice` takes a wave file path as input, buffer audio chunks to a queue in the `consume_nonblocking` function, and then writes these chunks to the wave file on termination.