### PR TITLE
Allow GoodbyeModel to work with Azure OpenAI

### DIFF
--- a/vocode/streaming/utils/goodbye_model.py
+++ b/vocode/streaming/utils/goodbye_model.py
@@ -65,11 +65,18 @@ class GoodbyeModel:
         return np.max(similarity_results) > SIMILARITY_THRESHOLD
 
     async def create_embedding(self, text) -> np.ndarray:
+        params = {
+            "input": text,
+            "model": "text-embedding-ada-002",
+        }
+
+        engine = getenv("AZURE_OPENAI_TEXT_EMBEDDING_ENGINE")
+        if engine is not None:
+            params["engine"] = engine
+
         return np.array(
             (
-                await openai.Embedding.acreate(
-                    input=text, model="text-embedding-ada-002"
-                )
+                await openai.Embedding.acreate(**params)
             )["data"][0]["embedding"]
         )
 

--- a/vocode/streaming/utils/goodbye_model.py
+++ b/vocode/streaming/utils/goodbye_model.py
@@ -67,17 +67,16 @@ class GoodbyeModel:
     async def create_embedding(self, text) -> np.ndarray:
         params = {
             "input": text,
-            "model": "text-embedding-ada-002",
         }
 
         engine = getenv("AZURE_OPENAI_TEXT_EMBEDDING_ENGINE")
         if engine is not None:
             params["engine"] = engine
+        else:
+            params["model"] = "text-embedding-ada-002"
 
         return np.array(
-            (
-                await openai.Embedding.acreate(**params)
-            )["data"][0]["embedding"]
+            (await openai.Embedding.acreate(**params))["data"][0]["embedding"]
         )
 
 


### PR DESCRIPTION
Discussion here:
https://discord.com/channels/1079125925163180093/1111176074991247410/1111176078803882014

@Kian1354 recently added support for using the Azure-hosted version of OpenAI:
https://github.com/vocodedev/vocode-python/pull/165

I found that this does work in general, and based on my initial tests it also seems to be a bit faster.

But, it fails when I use this flag:
```
end_conversation_on_goodbye=True
```

The error is this:
```
Traceback (most recent call last):
  File "/Users/shahafabileah/miniconda3/lib/python3.10/site-packages/vocode/streaming/utils/worker.py", line 167, in _run_loop
    await self.current_task
  File "/Users/shahafabileah/miniconda3/lib/python3.10/site-packages/vocode/streaming/agent/base_agent.py", line 215, in process
    goodbye_detected = await asyncio.wait_for(
  File "/Users/shahafabileah/miniconda3/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
    return fut.result()
  File "/Users/shahafabileah/miniconda3/lib/python3.10/site-packages/vocode/streaming/utils/goodbye_model.py", line 63, in is_goodbye
    embedding = await self.create_embedding(text.strip().lower())
  File "/Users/shahafabileah/miniconda3/lib/python3.10/site-packages/vocode/streaming/utils/goodbye_model.py", line 70, in create_embedding
    await openai.Embedding.acreate(
  File "/Users/shahafabileah/miniconda3/lib/python3.10/site-packages/openai/api_resources/embedding.py", line 73, in acreate
    response = await super().acreate(*args, **kwargs)
  File "/Users/shahafabileah/miniconda3/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 214, in acreate
    ) = cls.__prepare_create_request(
  File "/Users/shahafabileah/miniconda3/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 83, in __prepare_create_request
    raise error.InvalidRequestError(
openai.error.InvalidRequestError: Must provide an 'engine' or 'deployment_id' parameter to create a <class 'openai.api_resources.embedding.Embedding'>
```

In other words, `openai` has already been initialized to use `azure`, so it expected to be given an `engine` anytime you call it for anything.  But here we have `GoodbyeModel` calling it _without_ providing an `engine`, so it chokes.

A further complexity is that for `GoodbyeModel` we actually need a _different_ `engine`.  In Azure parlance, an "engine" is kind of like a "deployment" of a particular kind of model.  The model needed by GoodbyeModel is `text-embedding-ada-002`, so it gets its own deployment, separate from gpt-3.5 or whatnot.

The change I made here is the minimal change that seems to work.  You just define one more environment variable (`AZURE_OPENAI_TEXT_EMBEDDING_ENGINE `) with the name of the engine/deployment for embeddings, and you're good to go.

But this does raise questions about how we should manage openai setup in general, because I see it used in a few places:
* chat_gpt_agent.py
* goodbye_model.py
* llm_agent.py
* whisper_transcriber.py

BTW, note that this gets even more complicated, because at the moment Azure doesn't offer whisper (https://learn.microsoft.com/en-us/azure/cognitive-services/openai/concepts/models), so people who opt for Azure-hosted in general may still need to use OpenAI-hosted for whisper (and I don't know if the `openai` library can be made to work with two masters at the same time).

With ChatGPTAgent, the approach you took is to provide a ChatGPTAgentConfig, which gets _some_ values from environment variables and some from directly-given parameters (or defaults).  It might be nice to pass that same config around wherever else it's needed, but GoodbyeModel is created by BaseAgent, which is not GPT-specific and (I think) doesn't have access to those GPT-specific config params.  Maybe it's better to move in the direction of using environment variables for _all_ the openai setup stuff?  Or maybe it's best to consolidate openai setup somewhere, or give access to openai through a wrapper, or something.