### PR TITLE
Warn and return on empty transcripts

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -91,6 +91,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
 
         async def process(self, transcription: Transcription):
             self.conversation.mark_last_action_timestamp()
+            if transcription.message.strip() == "":
+                self.conversation.logger.info("Ignoring empty transcription")
+                return
             if transcription.is_final:
                 self.conversation.logger.debug(
                     "Got transcription: {}, confidence: {}".format(


### PR DESCRIPTION
I regularly get empty transcripts (mostly been using Azure transcriber). While the best would be to find a way to not get them from the source API, I guess we can't guarantee it, so I think vocode should handle the case somehow. Here is a simple fix that simply ignores the transcript if it's empty, but happy to hear if there is a better way to handle it?