### PR TITLE
Support text input

### DIFF
--- a/vocode/streaming/models/websocket.py
+++ b/vocode/streaming/models/websocket.py
@@ -14,6 +14,7 @@ class WebSocketMessageType(str, Enum):
     BASE = "websocket_base"
     START = "websocket_start"
     AUDIO = "websocket_audio"
+    TEXT = "websocket_text"
     READY = "websocket_ready"
     STOP = "websocket_stop"
     AUDIO_CONFIG_START = "websocket_audio_config_start"
@@ -48,6 +49,10 @@ class AudioConfigStartMessage(
     output_audio_config: OutputAudioConfig
     conversation_id: Optional[str] = None
 
+class TextMessage(WebSocketMessage, type=WebSocketMessageType.TEXT):
+    text: str
+    sender: str
+    is_final: bool
 
 class ReadyMessage(WebSocketMessage, type=WebSocketMessageType.READY):
     pass

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -454,12 +454,12 @@ class StreamingConversation(Generic[OutputDeviceType]):
             self.bot_sentiment = new_bot_sentiment
 
     async def receive_message(self, message: str):
-        transcripion = Transcription(
+        transcription = Transcription(
             message=message,
             confidence=1.0,
             is_final=True,
         )
-        await self.transcriptions_worker.process(transcripion)
+        await self.transcriptions_worker.process(transcription)
 
     def receive_audio(self, chunk: bytes):
         self.transcriber.send_audio(chunk)

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -453,6 +453,14 @@ class StreamingConversation(Generic[OutputDeviceType]):
             self.logger.debug("Bot sentiment: %s", new_bot_sentiment)
             self.bot_sentiment = new_bot_sentiment
 
+    async def receive_message(self, message: str):
+        transcripion = Transcription(
+            message=message,
+            confidence=1.0,
+            is_final=True,
+        )
+        await self.transcriptions_worker.process(transcripion)
+
     def receive_audio(self, chunk: bytes):
         self.transcriber.send_audio(chunk)
 

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -453,7 +453,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             self.logger.debug("Bot sentiment: %s", new_bot_sentiment)
             self.bot_sentiment = new_bot_sentiment
 
-    async def receive_message(self, message: str):
+   def receive_message(self, message: str):
         transcription = Transcription(
             message=message,
             confidence=1.0,

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -459,7 +459,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             confidence=1.0,
             is_final=True,
         )
-        await self.transcriptions_worker.process(transcription)
+        self.transcriptions_worker.consume_nonblocking(transcription)
 
     def receive_audio(self, chunk: bytes):
         self.transcriber.send_audio(chunk)

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -453,7 +453,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             self.logger.debug("Bot sentiment: %s", new_bot_sentiment)
             self.bot_sentiment = new_bot_sentiment
 
-   def receive_message(self, message: str):
+    def receive_message(self, message: str):
         transcription = Transcription(
             message=message,
             confidence=1.0,


### PR DESCRIPTION
Just a simple suggestion for the conversation API to support receiving text input in addition to audio. This allows apps using vocode to support mixed mode communication (e.g. people who can't or don't want to speak). Although I realize full support for text in/out requires a bit more, maybe this is an ok first step?