### PR TITLE
Support switching between azure-gpt and openai-gpt agents

### DIFF
--- a/vocode/streaming/agent/chat_gpt_agent.py
+++ b/vocode/streaming/agent/chat_gpt_agent.py
@@ -31,6 +31,9 @@ class ChatGPTAgent(RespondAgent[ChatGPTAgentConfig]):
             openai.api_version = agent_config.azure_params.api_version
             openai.api_key = getenv("AZURE_OPENAI_API_KEY")
         else:
+            openai.api_type = "open_ai"
+            openai.api_base = "https://api.openai.com/v1"
+            openai.api_version = None
             openai.api_key = openai_api_key or getenv("OPENAI_API_KEY")
         if not openai.api_key:
             raise ValueError("OPENAI_API_KEY must be set in environment or passed in")


### PR DESCRIPTION
Creating an AzureGPT agent and then a standard OpenAI GPT agent was broken due to openai's API base path being a global variable. This PR sets the variables back to their defaults when creating an OpenAI GPT agent.