### PR TITLE
Removes OFFSET_SECONDS from Google synthesizer

### DIFF
--- a/vocode/streaming/synthesizer/google_synthesizer.py
+++ b/vocode/streaming/synthesizer/google_synthesizer.py
@@ -24,7 +24,6 @@ from opentelemetry.context.context import Context
 
 
 class GoogleSynthesizer(BaseSynthesizer[GoogleSynthesizerConfig]):
-    OFFSET_SECONDS = 0.5
 
     def __init__(
         self,
@@ -100,14 +99,12 @@ class GoogleSynthesizer(BaseSynthesizer[GoogleSynthesizerConfig]):
         )
         output_sample_rate = response.audio_config.sample_rate_hertz
 
-        real_offset = int(GoogleSynthesizer.OFFSET_SECONDS * output_sample_rate)
-
         output_bytes_io = io.BytesIO()
         in_memory_wav = wave.open(output_bytes_io, "wb")
         in_memory_wav.setnchannels(1)
         in_memory_wav.setsampwidth(2)
         in_memory_wav.setframerate(output_sample_rate)
-        in_memory_wav.writeframes(response.audio_content[real_offset:-real_offset])
+        in_memory_wav.writeframes(response.audio_content)
         output_bytes_io.seek(0)
 
         result = self.create_synthesis_result_from_wav(


### PR DESCRIPTION
When using the Google synthesizer, it tended to previously cut off the first word. 
E.g. "Hi there" --> "-there" 

This is a simple fix that drops the offset from the google synthesizer. It was reported a long time ago in the discord, but no one followed up :(

![image](https://github.com/vocodedev/vocode-python/assets/7689776/bc3ea638-53e1-4e43-95f9-ab1f26fb232e)


Tested:
Tested locally using a self-hosted project calling the telephony service through an OutboundCall. 