### PR TITLE
Fix agent streaming sentence splitting

### DIFF
--- a/tests/streaming/agent/test_utils.py
+++ b/tests/streaming/agent/test_utils.py
@@ -54,6 +54,21 @@ OPENAI_OBJECTS = [
     ],
     [
         {"delta": {"role": "assistant"}, "finish_reason": None},
+        {"delta": {"content": "This"}, "finish_reason": None},
+        {"delta": {"content": " is"}, "finish_reason": None},
+        {"delta": {"content": " a"}, "finish_reason": None},
+        {"delta": {"content": " test"}, "finish_reason": None},
+        {"delta": {"content": " sentence."}, "finish_reason": None},
+        {"delta": {"content": " Want"}, "finish_reason": None},
+        {"delta": {"content": " to"}, "finish_reason": None},
+        {"delta": {"content": " hear"}, "finish_reason": None},
+        {"delta": {"content": " a"}, "finish_reason": None},
+        {"delta": {"content": " joke"}, "finish_reason": None},
+        {"delta": {"content": "?"}, "finish_reason": None},
+        {"delta": {}, "finish_reason": "stop"},
+    ],
+    [
+        {"delta": {"role": "assistant"}, "finish_reason": None},
         {"delta": {"content": "Sure"}, "finish_reason": None},
         {"delta": {"content": ","}, "finish_reason": None},
         {"delta": {"content": " here"}, "finish_reason": None},
@@ -126,11 +141,40 @@ OPENAI_OBJECTS = [
         {"delta": {"content": "."}, "finish_reason": None},
         {"delta": {}, "finish_reason": "stop"},
     ],
+    [
+        {"delta": {"role": "assistant"}, "finish_reason": None},
+        {"delta": {"content": "$"}, "finish_reason": None},
+        {"delta": {"content": "2"}, "finish_reason": None},
+        {"delta": {"content": " +"}, "finish_reason": None},
+        {"delta": {"content": " $"}, "finish_reason": None},
+        {"delta": {"content": "3"}, "finish_reason": None},
+        {"delta": {"content": "."}, "finish_reason": None},
+        {"delta": {"content": "00"}, "finish_reason": None},
+        {"delta": {"content": " is"}, "finish_reason": None},
+        {"delta": {"content": " equal"}, "finish_reason": None},
+        {"delta": {"content": " to"}, "finish_reason": None},
+        {"delta": {"content": " $"}, "finish_reason": None},
+        {"delta": {"content": "5"}, "finish_reason": None},
+        {"delta": {"content": "."}, "finish_reason": None},
+        {"delta": {"content": " $"}, "finish_reason": None},
+        {"delta": {"content": "6"}, "finish_reason": None},
+        {"delta": {"content": " +"}, "finish_reason": None},
+        {"delta": {"content": " $"}, "finish_reason": None},
+        {"delta": {"content": "4"}, "finish_reason": None},
+        {"delta": {"content": " is"}, "finish_reason": None},
+        {"delta": {"content": " equal"}, "finish_reason": None},
+        {"delta": {"content": " to"}, "finish_reason": None},
+        {"delta": {"content": " $"}, "finish_reason": None},
+        {"delta": {"content": "10"}, "finish_reason": None},
+        {"delta": {"content": "."}, "finish_reason": None},
+        {"delta": {}, "finish_reason": "stop"},
+    ],
 ]
 
 EXPECTED_SENTENCES = [
     ["Hello!", "How are you doing today?"],
     ["Hello.", "What do you want to talk about?"],
+    ["This is a test sentence.", "Want to hear a joke?"],
     [
         "Sure, here are three possible things we could talk about:",
         "1. Goals and aspirations",
@@ -140,6 +184,10 @@ EXPECTED_SENTENCES = [
     [
         "$1 + $3.20 is equal to $4.20.",
         "And $1.40 plus $2.80 is equal to $4.20 as well.",
+    ],
+    [
+        "$2 + $3.00 is equal to $5.",
+        "$6 + $4 is equal to $10.",
     ],
 ]
 

--- a/tests/streaming/agent/test_utils.py
+++ b/tests/streaming/agent/test_utils.py
@@ -40,6 +40,20 @@ OPENAI_OBJECTS = [
     ],
     [
         {"delta": {"role": "assistant"}, "finish_reason": None},
+        {"delta": {"content": "Hello"}, "finish_reason": None},
+        {"delta": {"content": "."}, "finish_reason": None},
+        {"delta": {"content": " What"}, "finish_reason": None},
+        {"delta": {"content": " do"}, "finish_reason": None},
+        {"delta": {"content": " you"}, "finish_reason": None},
+        {"delta": {"content": " want"}, "finish_reason": None},
+        {"delta": {"content": " to"}, "finish_reason": None},
+        {"delta": {"content": " talk"}, "finish_reason": None},
+        {"delta": {"content": " about"}, "finish_reason": None},
+        {"delta": {"content": "?"}, "finish_reason": None},
+        {"delta": {}, "finish_reason": "stop"},
+    ],
+    [
+        {"delta": {"role": "assistant"}, "finish_reason": None},
         {"delta": {"content": "Sure"}, "finish_reason": None},
         {"delta": {"content": ","}, "finish_reason": None},
         {"delta": {"content": " here"}, "finish_reason": None},
@@ -116,6 +130,7 @@ OPENAI_OBJECTS = [
 
 EXPECTED_SENTENCES = [
     ["Hello!", "How are you doing today?"],
+    ["Hello.", "What do you want to talk about?"],
     [
         "Sure, here are three possible things we could talk about:",
         "1. Goals and aspirations",

--- a/vocode/streaming/agent/utils.py
+++ b/vocode/streaming/agent/utils.py
@@ -8,39 +8,13 @@ from vocode.streaming.models.transcript import Action, Message, Transcript
 SENTENCE_ENDINGS = [".", "!", "?", "\n"]
 
 
-def _sent_tokenize(text: str, sentence_endings: List[str]) -> List[str]:
-    sentence_endings = [e for e in sentence_endings if e != "."]
-    sentence_endings_pattern = "|".join(map(re.escape, sentence_endings))
-
-    # Replace sentence endings with a unique marker
-    text = re.sub(f"([{sentence_endings_pattern}])", r"\1<END>", text)
-
-    sentences = text.split("<END>")
-
-    # Additional logic to handle numbered list items
-    combined_sentences = []
-    buffer = ""
-    for sentence in sentences:
-        # If the sentence starts with a number and a space, it's part of a list
-        if re.match(r"^\d+ ", sentence):
-            buffer += sentence + " "
-        else:
-            if buffer:
-                # Add the current buffer to combined_sentences and start a new buffer
-                combined_sentences.append(buffer.strip())
-                buffer = ""
-            combined_sentences.append(sentence)
-    if buffer:
-        combined_sentences.append(buffer.strip())
-
-    return combined_sentences
-
-
 async def stream_openai_response_async(
     gen: AsyncIterable[OpenAIObject],
     get_text: Callable[[dict], str],
     sentence_endings: List[str] = SENTENCE_ENDINGS,
 ) -> AsyncGenerator:
+    sentence_endings_pattern = "|".join(map(re.escape, sentence_endings))
+    list_item_ending_pattern = r"\n"
     buffer = ""
     async for event in gen:
         choices = event.get("choices", [])
@@ -52,13 +26,21 @@ async def stream_openai_response_async(
         token = get_text(choice)
         if not token:
             continue
-        buffer += token
 
-        sentences = _sent_tokenize(buffer, sentence_endings)
-        for sentence in sentences[:-1]:
-            if sentence.strip():
-                yield sentence.strip()
-        buffer = sentences[-1]
+        buffer += token
+        possible_list_item = re.match(r"^\d+[ .]", buffer)
+        if re.findall(
+            list_item_ending_pattern
+            if possible_list_item
+            else sentence_endings_pattern,
+            token,
+        ):
+            ends_with_money = re.findall(r"\$\d+.$", buffer)
+            if not ends_with_money:
+                to_return = buffer.strip()
+                if to_return:
+                    yield to_return
+                buffer = ""
     if buffer.strip():
         yield buffer
 

--- a/vocode/streaming/agent/utils.py
+++ b/vocode/streaming/agent/utils.py
@@ -33,8 +33,8 @@ async def stream_openai_response_async(
             buffer = ""
 
         buffer += token
-        possible_list_item = re.match(r"^\d+[ .]", buffer)
-        ends_with_money = re.findall(r"\$\d+.$", buffer)
+        possible_list_item = bool(re.match(r"^\d+[ .]", buffer))
+        ends_with_money = bool(re.findall(r"\$\d+.$", buffer))
         if re.findall(
             list_item_ending_pattern
             if possible_list_item


### PR DESCRIPTION
Adds the simplest test case that the current algorithm fails. Replaces the current algorithm with one that passes all the tests. More tests should probably be added and the algorithm should probably be expanded a little to handle more cases (for example, if a sentence ends with `$4.` then it should be split).