### PR TITLE
Fix AzureSynthesizer hanging on some input messages

### DIFF
--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -35,10 +35,6 @@ ElementTree.register_namespace("", NAMESPACES[""])
 ElementTree.register_namespace("mstts", NAMESPACES["mstts"])
 
 
-async def empty_generator():
-    yield SynthesisResult.ChunkResult(b"", True)
-
-
 class WordBoundaryEventPool:
     def __init__(self):
         self.events = []
@@ -230,7 +226,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
         # generator for these cases.
         if not re.match(r"\w", message.text):
             return SynthesisResult(
-                empty_generator(),
+                self.empty_generator(),
                 lambda _: message.text,
             )
 

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -35,6 +35,10 @@ ElementTree.register_namespace("", NAMESPACES[""])
 ElementTree.register_namespace("mstts", NAMESPACES["mstts"])
 
 
+async def empty_generator():
+    yield SynthesisResult.ChunkResult(b"", True)
+
+
 class WordBoundaryEventPool:
     def __init__(self):
         self.events = []
@@ -220,9 +224,6 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
         # offset = int(self.OFFSET_MS * (self.synthesizer_config.sampling_rate / 1000))
         offset = 0
         self.logger.debug(f"Synthesizing message: {message}")
-
-        async def empty_generator():
-            yield SynthesisResult.ChunkResult(b"", True)
 
         # Azure will return no audio for certain strings like "-", "[-", and "!"
         # which causes the `chunk_generator` below to hang. Return an empty

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -221,6 +221,18 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
         offset = 0
         self.logger.debug(f"Synthesizing message: {message}")
 
+        async def empty_generator():
+            yield SynthesisResult.ChunkResult(b"", True)
+
+        # Azure will return no audio for certain strings like "-", "[-", and "!"
+        # which causes the `chunk_generator` below to hang. Return an empty
+        # generator for these cases.
+        if not re.match(r"\w", message.text):
+            return SynthesisResult(
+                empty_generator(),
+                lambda _: message.text,
+            )
+
         async def chunk_generator(
             audio_data_stream: speechsdk.AudioDataStream, chunk_transform=lambda x: x
         ):

--- a/vocode/streaming/synthesizer/base_synthesizer.py
+++ b/vocode/streaming/synthesizer/base_synthesizer.py
@@ -123,6 +123,9 @@ class BaseSynthesizer(Generic[SynthesizerConfigType]):
             ), "MuLaw encoding only supports 8kHz sampling rate"
         self.filler_audios: List[FillerAudio] = []
 
+    async def empty_generator(self):
+        yield SynthesisResult.ChunkResult(b"", True)
+
     def get_synthesizer_config(self) -> SynthesizerConfig:
         return self.synthesizer_config
 


### PR DESCRIPTION
Azure will return no audio for certain strings like `-`, `[-`, and `!` which causes the `chunk_generator` in azure_synthesizer.py to hang on `audio_data_stream.can_read_data` since Azure will never send any data. This PR returns an empty generator for these cases by checking if there is at least one character matching the regex `\w` in the input message.