### PR TITLE
adds conversation state manager

### DIFF
--- a/vocode/streaming/action/base_action.py
+++ b/vocode/streaming/action/base_action.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generic, Type
+from typing import Any, Dict, Generic, Optional, Type
 from vocode.streaming.action.utils import exclude_keys_recursive
 from vocode.streaming.models.actions import (
     ActionInput,
@@ -7,6 +7,7 @@ from vocode.streaming.models.actions import (
     ParametersType,
     ResponseType,
 )
+from vocode.streaming.utils.state_manager import ConversationStateManager
 
 
 class BaseAction(Generic[ParametersType, ResponseType]):
@@ -15,6 +16,11 @@ class BaseAction(Generic[ParametersType, ResponseType]):
 
     def __init__(self, should_respond: bool = False):
         self.should_respond = should_respond
+
+    def attach_conversation_state_manager(
+        self, conversation_state_manager: ConversationStateManager
+    ):
+        self.conversation_state_manager = conversation_state_manager
 
     async def run(
         self, action_input: ActionInput[ParametersType]

--- a/vocode/streaming/agent/action_agent.py
+++ b/vocode/streaming/agent/action_agent.py
@@ -90,6 +90,9 @@ class ActionAgent(BaseAgent[ActionAgentConfig]):
                 )
             elif message.function_call:
                 action = self.action_factory.create_action(message.function_call.name)
+                action.attach_conversation_state_manager(
+                    self.conversation_state_manager
+                )
                 params = json.loads(message.function_call.arguments)
                 if "user_message" in params:
                     user_message = params["user_message"]

--- a/vocode/streaming/agent/action_agent.py
+++ b/vocode/streaming/agent/action_agent.py
@@ -90,9 +90,6 @@ class ActionAgent(BaseAgent[ActionAgentConfig]):
                 )
             elif message.function_call:
                 action = self.action_factory.create_action(message.function_call.name)
-                action.attach_conversation_state_manager(
-                    self.conversation_state_manager
-                )
                 params = json.loads(message.function_call.arguments)
                 if "user_message" in params:
                     user_message = params["user_message"]

--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -21,6 +21,7 @@ from vocode.streaming.transcriber.base_transcriber import Transcription
 from vocode.streaming.utils import remove_non_letters_digits
 from vocode.streaming.utils.goodbye_model import GoodbyeModel
 from vocode.streaming.models.transcript import Transcript
+from vocode.streaming.utils.state_manager import ConversationStateManager
 from vocode.streaming.utils.worker import (
     InterruptibleEvent,
     InterruptibleEventFactory,
@@ -132,6 +133,11 @@ class BaseAgent(AbstractAgent[AgentConfigType], InterruptibleWorker):
 
     def attach_transcript(self, transcript: Transcript):
         self.transcript = transcript
+
+    def attach_conversation_state_manager(
+        self, conversation_state_manager: ConversationStateManager
+    ):
+        self.conversation_state_manager = conversation_state_manager
 
     def start(self):
         super().start()

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -18,7 +18,7 @@ from vocode.streaming.agent.bot_sentiment_analyser import (
 from vocode.streaming.models.actions import ActionInput
 from vocode.streaming.models.transcript import Transcript, TranscriptCompleteEvent
 from vocode.streaming.models.message import BaseMessage
-from vocode.streaming.models.transcriber import TranscriberConfig
+from vocode.streaming.models.transcriber import EndpointingConfig, TranscriberConfig
 from vocode.streaming.output_device.base_output_device import BaseOutputDevice
 from vocode.streaming.utils.conversation_logger_adapter import wrap_logger
 from vocode.streaming.utils.events_manager import EventsManager
@@ -53,6 +53,7 @@ from vocode.streaming.transcriber.base_transcriber import (
     Transcription,
     BaseTranscriber,
 )
+from vocode.streaming.utils.state_manager import ConversationStateManager
 from vocode.streaming.utils.worker import (
     AsyncQueueWorker,
     InterruptibleEvent,
@@ -340,6 +341,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.filler_audio_queue: asyncio.Queue[
             InterruptibleEvent[FillerAudio]
         ] = asyncio.Queue()
+        self.state_manager = ConversationStateManager(conversation=self)
         self.transcriptions_worker = self.TranscriptionsWorker(
             input_queue=self.transcriber.output_queue,
             output_queue=self.agent.get_input_queue(),

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -348,6 +348,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
             conversation=self,
             interruptible_event_factory=self.interruptible_event_factory,
         )
+        self.agent.attach_conversation_state_manager(self.state_manager)
         self.agent_responses_worker = self.AgentResponsesWorker(
             input_queue=self.agent.get_output_queue(),
             output_queue=self.synthesis_results_queue,
@@ -362,6 +363,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 interruptible_event_factory=self.interruptible_event_factory,
                 action_factory=self.agent.action_factory,
             )
+            self.actions_worker.attach_conversation_state_manager(self.state_manager)
         self.synthesis_results_worker = self.SynthesisResultsWorker(
             input_queue=self.synthesis_results_queue, conversation=self
         )

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -341,7 +341,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
         self.filler_audio_queue: asyncio.Queue[
             InterruptibleEvent[FillerAudio]
         ] = asyncio.Queue()
-        self.state_manager = ConversationStateManager(conversation=self)
+        self.state_manager = self.create_state_manager()
         self.transcriptions_worker = self.TranscriptionsWorker(
             input_queue=self.transcriber.output_queue,
             output_queue=self.agent.get_input_queue(),
@@ -400,6 +400,9 @@ class StreamingConversation(Generic[OutputDeviceType]):
         # tracing
         self.start_time: Optional[float] = None
         self.end_time: Optional[float] = None
+
+    def create_state_manager(self) -> ConversationStateManager:
+        return ConversationStateManager(conversation=self)
 
     async def start(self, mark_ready: Optional[Callable[[], Awaitable[None]]] = None):
         self.transcriber.start()

--- a/vocode/streaming/telephony/conversation/twilio_call.py
+++ b/vocode/streaming/telephony/conversation/twilio_call.py
@@ -25,6 +25,7 @@ from vocode.streaming.telephony.config_manager.base_config_manager import (
 from vocode.streaming.telephony.conversation.call import Call
 from vocode.streaming.transcriber.factory import TranscriberFactory
 from vocode.streaming.utils.events_manager import EventsManager
+from vocode.streaming.utils.state_manager import TwilioCallStateManager
 
 
 class PhoneCallWebsocketAction(Enum):
@@ -77,6 +78,9 @@ class TwilioCall(Call[TwilioOutputDevice]):
         )
         self.twilio_sid = twilio_sid
         self.latest_media_timestamp = 0
+
+    def create_state_manager(self) -> TwilioCallStateManager:
+        return TwilioCallStateManager(self)
 
     async def attach_ws_and_start(self, ws: WebSocket):
         super().attach_ws(ws)

--- a/vocode/streaming/telephony/conversation/vonage_call.py
+++ b/vocode/streaming/telephony/conversation/vonage_call.py
@@ -25,6 +25,11 @@ from vocode.streaming.utils.events_manager import EventsManager
 
 from vocode.streaming.output_device.speaker_output import SpeakerOutput
 from vocode.streaming.telephony.constants import VONAGE_CHUNK_SIZE, VONAGE_SAMPLING_RATE
+from vocode.streaming.utils.state_manager import (
+    ConversationStateManager,
+    VonageCallStateManager,
+)
+
 
 class VonageCall(Call[VonageOutputDevice]):
     def __init__(
@@ -81,6 +86,9 @@ class VonageCall(Call[VonageOutputDevice]):
             base_url=base_url, vonage_config=self.vonage_config
         )
         self.vonage_uuid = vonage_uuid
+
+    def create_state_manager(self) -> VonageCallStateManager:
+        return VonageCallStateManager(self)
 
     # TODO(EPD-186) - make this function async and use aiohttp with the vonage client
     def send_dtmf(self, digits: str):

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -3,6 +3,8 @@ from vocode.streaming.models.transcriber import EndpointingConfig
 
 if TYPE_CHECKING:
     from vocode.streaming.streaming_conversation import StreamingConversation
+    from vocode.streaming.telephony.conversation.vonage_call import VonageCall
+    from vocode.streaming.telephony.conversation.twilio_call import TwilioCall
 
 
 class ConversationStateManager:
@@ -19,3 +21,15 @@ class ConversationStateManager:
         self._conversation.transcriber.get_transcriber_config().endpointing_config = (
             endpointing_config
         )
+
+
+class VonageCallStateManager(ConversationStateManager):
+    def __init__(self, call: "VonageCall"):
+        super().__init__(call)
+        self._call = call
+
+
+class TwilioCallStateManager(ConversationStateManager):
+    def __init__(self, call: "TwilioCall"):
+        super().__init__(call)
+        self._call = call

--- a/vocode/streaming/utils/state_manager.py
+++ b/vocode/streaming/utils/state_manager.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING, Optional
+from vocode.streaming.models.transcriber import EndpointingConfig
+
+if TYPE_CHECKING:
+    from vocode.streaming.streaming_conversation import StreamingConversation
+
+
+class ConversationStateManager:
+    def __init__(self, conversation: "StreamingConversation"):
+        self._conversation = conversation
+
+    def get_transcriber_endpointing_config(self) -> Optional[EndpointingConfig]:
+        return (
+            self._conversation.transcriber.get_transcriber_config().endpointing_config
+        )
+
+    def set_transcriber_endpointing_config(self, endpointing_config: EndpointingConfig):
+        assert self.get_transcriber_endpointing_config() is not None
+        self._conversation.transcriber.get_transcriber_config().endpointing_config = (
+            endpointing_config
+        )


### PR DESCRIPTION
Introduces `ConversationStateManager` which is an interface for `Agent`s and `Action`s to have access / interact with `StreamingConversation`:
- when an `Agent` or `Action` wants to access the conversation, they can use the exposed interface in the state manager to take effects: for example, the speed of the synthesizer can be updated by an `Agent` or `Action`

- also creates `VonageCallStateManager` and `TwilioCallStateManager` to access state of a `VonageCall` and `TwilioCall`