### PR TITLE
fixes typing in phone call actions

### DIFF
--- a/vocode/streaming/action/phone_call_action.py
+++ b/vocode/streaming/action/phone_call_action.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from vocode.streaming.action.base_action import BaseAction
 from vocode.streaming.models.actions import (
+    ActionInput,
     ActionOutput,
     ParametersType,
     ResponseType,
@@ -22,6 +23,10 @@ class VonagePhoneCallAction(BaseAction[ParametersType, ResponseType]):
             vonage_uuid=vonage_uuid,
         )
 
+    def get_vonage_uuid(self, action_input: ActionInput[ParametersType]) -> str:
+        assert isinstance(action_input, VonagePhoneCallActionInput)
+        return action_input.vonage_uuid
+
 
 class TwilioPhoneCallAction(BaseAction[ParametersType, ResponseType]):
     def create_phone_call_action_input(
@@ -35,3 +40,7 @@ class TwilioPhoneCallAction(BaseAction[ParametersType, ResponseType]):
             params=self.parameters_type(**params),
             twilio_sid=twilio_sid,
         )
+
+    def get_twilio_sid(self, action_input: ActionInput[ParametersType]) -> str:
+        assert isinstance(action_input, TwilioPhoneCallActionInput)
+        return action_input.twilio_sid


### PR DESCRIPTION
earlier, the signature of `run` needed to be `VonagePhoneCallActionInput` to get access to `vonage_uuid` but this violates LSP: adds `get_vonage_uuid` (and stuff for Twilio) exactly for this case