### PR TITLE
allow for leading non words in AzureSynthesizer

### DIFF
--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -224,7 +224,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
         # Azure will return no audio for certain strings like "-", "[-", and "!"
         # which causes the `chunk_generator` below to hang. Return an empty
         # generator for these cases.
-        if not re.match(r"\w", message.text):
+        if not re.findall(r"\w", message.text):
             return SynthesisResult(
                 self.empty_generator(),
                 lambda _: message.text,


### PR DESCRIPTION
we added a check in https://github.com/vocodedev/vocode-python/pull/233 to make sure we were sending inputs to the Azure Synthesizer that wouldn't gives us back empty responses, which mess with the rest of the pipeline

- we should be using `findall` instead of `match` otherwise strings like " Hello" aren't matched

cc @HHousen 