### PR TITLE
Update Rime Synthesizer to support different configurations

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -132,13 +132,13 @@ class ElevenLabsSynthesizerConfig(
 
 
 RIME_DEFAULT_SPEAKER = "young_male_unmarked-1"
-RIME_DEFAULT_SAMPLE_RATE = 8000
+RIME_DEFAULT_SAMPLE_RATE = 22050
 RIME_DEFAULT_BASE_URL = "https://rjmopratfrdjgmfmaios.functions.supabase.co/rime-tts"
 
 class RimeSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.RIME.value):
-    speaker: Optional[str] = RIME_DEFAULT_SPEAKER
-    sampling_rate: Optional[int] = RIME_DEFAULT_SAMPLE_RATE
-    base_url: Optional[str] = RIME_DEFAULT_BASE_URL
+    speaker: str = RIME_DEFAULT_SPEAKER
+    sampling_rate: int = RIME_DEFAULT_SAMPLE_RATE
+    base_url: str = RIME_DEFAULT_BASE_URL
 
 
 

--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -132,10 +132,14 @@ class ElevenLabsSynthesizerConfig(
 
 
 RIME_DEFAULT_SPEAKER = "young_male_unmarked-1"
-
+RIME_DEFAULT_SAMPLE_RATE = 8000
+RIME_DEFAULT_BASE_URL = "https://rjmopratfrdjgmfmaios.functions.supabase.co/rime-tts"
 
 class RimeSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.RIME.value):
-    speaker: str = RIME_DEFAULT_SPEAKER
+    speaker: Optional[str] = RIME_DEFAULT_SPEAKER
+    sampling_rate: Optional[int] = RIME_DEFAULT_SAMPLE_RATE
+    base_url: Optional[str] = RIME_DEFAULT_BASE_URL
+
 
 
 COQUI_DEFAULT_SPEAKER_ID = "ebe2db86-62a6-49a1-907a-9a1360d4416e"

--- a/vocode/streaming/synthesizer/rime_synthesizer.py
+++ b/vocode/streaming/synthesizer/rime_synthesizer.py
@@ -24,9 +24,6 @@ from vocode.streaming.models.synthesizer import RimeSynthesizerConfig, Synthesiz
 from opentelemetry.context.context import Context
 
 # https://rime.ai/docs/quickstart
-RIME_SAMPLING_RATE = 22050
-RIME_BASE_URL = "https://rjmopratfrdjgmfmaios.functions.supabase.co/rime-tts"
-
 
 class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
     def __init__(
@@ -37,6 +34,8 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         super().__init__(synthesizer_config)
         self.api_key = getenv("RIME_API_KEY")
         self.speaker = synthesizer_config.speaker
+        self.samplingRate = synthesizer_config.sampling_rate
+        self.baseUrl = synthesizer_config.base_url
 
     async def create_speech(
         self,
@@ -52,13 +51,14 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         body = {
             "text": message.text,
             "speaker": self.speaker,
+            "samplingRate": self.samplingRate
         }
         create_speech_span = tracer.start_span(
             f"synthesizer.{SynthesizerType.RIME.value.split('_', 1)[-1]}.create_total",
         )
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                RIME_BASE_URL,
+                self.baseUrl,
                 headers=headers,
                 json=body,
                 timeout=aiohttp.ClientTimeout(total=15),

--- a/vocode/streaming/synthesizer/rime_synthesizer.py
+++ b/vocode/streaming/synthesizer/rime_synthesizer.py
@@ -35,7 +35,7 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         self.api_key = getenv("RIME_API_KEY")
         self.speaker = synthesizer_config.speaker
         self.sampling_rate = synthesizer_config.sampling_rate
-        self.baseUrl = synthesizer_config.base_url
+        self.base_url = synthesizer_config.base_url
 
     async def create_speech(
         self,
@@ -58,7 +58,7 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         )
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                self.baseUrl,
+                self.base_url,
                 headers=headers,
                 json=body,
                 timeout=aiohttp.ClientTimeout(total=15),

--- a/vocode/streaming/synthesizer/rime_synthesizer.py
+++ b/vocode/streaming/synthesizer/rime_synthesizer.py
@@ -34,7 +34,7 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         super().__init__(synthesizer_config)
         self.api_key = getenv("RIME_API_KEY")
         self.speaker = synthesizer_config.speaker
-        self.samplingRate = synthesizer_config.sampling_rate
+        self.sampling_rate = synthesizer_config.sampling_rate
         self.baseUrl = synthesizer_config.base_url
 
     async def create_speech(
@@ -51,7 +51,7 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         body = {
             "text": message.text,
             "speaker": self.speaker,
-            "samplingRate": self.samplingRate
+            "samplingRate": self.sampling_rate
         }
         create_speech_span = tracer.start_span(
             f"synthesizer.{SynthesizerType.RIME.value.split('_', 1)[-1]}.create_total",


### PR DESCRIPTION
I attempted to add the ability to specify parameters like sampling rate and base url that rime continues to change as they mature. 

To do this, I moved the default values from the rime synthesizer to the rime synth config within synthesizer.py and made them optional. Within the synth (not config) I pulled the values from the new config. 

Please review