### PR TITLE
[EPD-230] Add call recording event for Vonage

### DIFF
--- a/docs/events-manager.mdx
+++ b/docs/events-manager.mdx
@@ -53,6 +53,7 @@ The current event types include:
 2. `TRANSCRIPT_COMPLETE`: Indicates the transcript is complete (ie conversation has ended).
 3. `PHONE_CALL_CONNECTED`: Indicates a phone call has been connected.
 4. `PHONE_CALL_ENDED`: Indicates a phone call has ended.
+5. `RECORDING`: (Vonage Only) Indicates a secure URL containing a recording of the call is available. Requires `recording=true` in `VonageConfig`.
 
 ## Example Usage
 

--- a/vocode/streaming/models/events.py
+++ b/vocode/streaming/models/events.py
@@ -13,6 +13,7 @@ class EventType(str, Enum):
     TRANSCRIPT_COMPLETE = "event_transcript_complete"
     PHONE_CALL_CONNECTED = "event_phone_call_connected"
     PHONE_CALL_ENDED = "event_phone_call_ended"
+    RECORDING = "event_recording"
 
 
 class Event(TypedModel):
@@ -26,3 +27,7 @@ class PhoneCallConnectedEvent(Event, type=EventType.PHONE_CALL_CONNECTED):
 
 class PhoneCallEndedEvent(Event, type=EventType.PHONE_CALL_ENDED):
     conversation_minutes: float = 0
+
+
+class RecordingEvent(Event, type=EventType.RECORDING):
+    recording_url: str

--- a/vocode/streaming/telephony/client/vonage_client.py
+++ b/vocode/streaming/telephony/client/vonage_client.py
@@ -34,7 +34,7 @@ class VonageClient(BaseTelephonyClient):
             {
                 "to": [{"type": "phone", "number": to_phone, "dtmfAnswer": digits}],
                 "from": {"type": "phone", "number": from_phone},
-                "ncco": self.create_call_ncco(self.base_url, conversation_id),
+                "ncco": self.create_call_ncco(self.base_url, conversation_id, record),
             }
         )
         if response["status"] != "started":
@@ -42,20 +42,25 @@ class VonageClient(BaseTelephonyClient):
         return response["uuid"]
 
     @staticmethod
-    def create_call_ncco(base_url, conversation_id):
-        return [
-            {
-                "action": "connect",
-                "endpoint": [
-                    {
-                        "type": "websocket",
-                        "uri": f"wss://{base_url}/connect_call/{conversation_id}",
-                        "content-type": VONAGE_CONTENT_TYPE,
-                        "headers": {},
-                    }
-                ],
-            }
-        ]
+    def create_call_ncco(base_url, conversation_id, record):
+        ncco = []
+        if record:
+            ncco.append({
+                "action": "record",
+                "eventUrl": [f"https://{base_url}/recordings/{conversation_id}"]
+            })
+        ncco.append({
+            "action": "connect",
+            "endpoint": [
+                {
+                    "type": "websocket",
+                    "uri": f"wss://{base_url}/connect_call/{conversation_id}",
+                    "content-type": VONAGE_CONTENT_TYPE,
+                    "headers": {},
+                }
+            ],
+        })
+        return ncco
 
     def end_call(self, id) -> bool:
         # TODO(EPD-186): return True if the call was ended successfully

--- a/vocode/streaming/telephony/server/base.py
+++ b/vocode/streaming/telephony/server/base.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Form, Request, Response
 from pydantic import BaseModel, Field
 from vocode.streaming.agent.factory import AgentFactory
 from vocode.streaming.models.agent import AgentConfig
+from vocode.streaming.models.events import RecordingEvent
 from vocode.streaming.models.synthesizer import SynthesizerConfig
 from vocode.streaming.models.transcriber import TranscriberConfig
 from vocode.streaming.synthesizer.factory import SynthesizerFactory
@@ -95,10 +96,19 @@ class TelephonyServer:
                 methods=["POST"],
             )
         # vonage requires an events endpoint
-        self.router.add_api_route("/events", self.events, methods=["GET"])
+        self.router.add_api_route("/events", self.events, methods=["GET", "POST"])
         self.logger.info(f"Set up events endpoint at https://{self.base_url}/events")
 
+        self.router.add_api_route("/recordings/{conversation_id}", self.recordings, methods=["GET", "POST"])
+        self.logger.info(f"Set up recordings endpoint at https://{self.base_url}/recordings/{{conversation_id}}")
+ 
     def events(self, request: Request):
+        return lambda: Response()
+
+    async def recordings(self, request: Request, conversation_id: str):
+        recording_url = (await request.json())["recording_url"]
+        if self.events_manager is not None and recording_url is not None:
+            self.events_manager.publish_event(RecordingEvent(recording_url=recording_url, conversation_id=conversation_id))
         return lambda: Response()
 
     def create_inbound_route(
@@ -146,7 +156,7 @@ class TelephonyServer:
             conversation_id = create_conversation_id()
             await self.config_manager.save_config(conversation_id, call_config)
             return VonageClient.create_call_ncco(
-                base_url=self.base_url, conversation_id=conversation_id
+                base_url=self.base_url, conversation_id=conversation_id, record=vonage_config.record
             )
 
         if isinstance(inbound_call_config, TwilioInboundCallConfig):

--- a/vocode/streaming/telephony/server/base.py
+++ b/vocode/streaming/telephony/server/base.py
@@ -103,13 +103,13 @@ class TelephonyServer:
         self.logger.info(f"Set up recordings endpoint at https://{self.base_url}/recordings/{{conversation_id}}")
  
     def events(self, request: Request):
-        return lambda: Response()
+        return Response()
 
     async def recordings(self, request: Request, conversation_id: str):
         recording_url = (await request.json())["recording_url"]
         if self.events_manager is not None and recording_url is not None:
             self.events_manager.publish_event(RecordingEvent(recording_url=recording_url, conversation_id=conversation_id))
-        return lambda: Response()
+        return Response()
 
     def create_inbound_route(
         self,


### PR DESCRIPTION
This pull request adds a new event type for Vonage calls: `RECORDING`. This event is triggered when a call is recorded and provides a secure URL containing the recording of the call. This feature requires setting `record=true` in the `VonageConfig` object. The pull request also updates the EventsManager documentation. Additionally, it fixes some environment variables and imports in the `VonageConfig` and `VonageClient` classes. 

The changes are:

- Added a new class `RecordingEvent` in `vocode/streaming/models/events.py` that inherits from `Event` and has a `recording_url` attribute.
- Added a new enum value `RECORDING` in `EventType` in `vocode/streaming/models/events.py`.
- Updated the `create_call_ncco` method in `VonageClient` in `vocode/streaming/telephony/client/vonage_client.py` to include a record action if `record=true` in the `VonageConfig`.
- Updated the `vonage_route` method in `TelephonyServerBase` in `vocode/streaming/telephony/server/base.py` to pass the record option to the `create_call_ncco` method.
- Added a new endpoint `/recordings/{conversation_id}` in `TelephonyServerBase` in `vocode/streaming/telephony/server/base.py` that handles the recording event from Vonage and publishes it to the events manager.
- Updated the `VonageConfig` class in `vocode/streaming/models/telephony.py` to use environment variables for the api key, secret, application id and private key, and to have a record option with default value false.
- Updated the documentation in `docs/events-manager.mdx` to include the new event type and its requirements.


TODO (for future PR?):
- Add Twilio support
