### PR TITLE
Add Quiet Actions (actions performed without generating another response)

### DIFF
--- a/vocode/streaming/action/base_action.py
+++ b/vocode/streaming/action/base_action.py
@@ -13,6 +13,7 @@ from vocode.streaming.utils.state_manager import ConversationStateManager
 class BaseAction(Generic[ParametersType, ResponseType]):
     description: str = ""
     action_type: str = ActionType.BASE.value
+    quiet: bool = False
 
     def __init__(self, should_respond: bool = False):
         self.should_respond = should_respond

--- a/vocode/streaming/action/base_action.py
+++ b/vocode/streaming/action/base_action.py
@@ -13,10 +13,10 @@ from vocode.streaming.utils.state_manager import ConversationStateManager
 class BaseAction(Generic[ParametersType, ResponseType]):
     description: str = ""
     action_type: str = ActionType.BASE.value
-    quiet: bool = False
 
-    def __init__(self, should_respond: bool = False):
+    def __init__(self, should_respond: bool = False, quiet: bool = False):
         self.should_respond = should_respond
+        self.quiet = quiet
 
     def attach_conversation_state_manager(
         self, conversation_state_manager: ConversationStateManager

--- a/vocode/streaming/action/worker.py
+++ b/vocode/streaming/action/worker.py
@@ -51,5 +51,6 @@ class ActionsWorker(InterruptibleWorker):
                 twilio_sid=action_input.twilio_sid
                 if isinstance(action_input, TwilioPhoneCallActionInput)
                 else None,
+                quiet_action=action.quiet,
             )
         )

--- a/vocode/streaming/action/worker.py
+++ b/vocode/streaming/action/worker.py
@@ -51,6 +51,6 @@ class ActionsWorker(InterruptibleWorker):
                 twilio_sid=action_input.twilio_sid
                 if isinstance(action_input, TwilioPhoneCallActionInput)
                 else None,
-                quiet_action=action.quiet,
+                is_quiet=action.quiet,
             )
         )

--- a/vocode/streaming/agent/action_agent.py
+++ b/vocode/streaming/agent/action_agent.py
@@ -68,7 +68,7 @@ class ActionAgent(BaseAgent[ActionAgentConfig]):
                     action_output=agent_input.action_output,
                     conversation_id=agent_input.conversation_id,
                 )
-                if agent_input.quiet_action:
+                if agent_input.is_quiet:
                     # Do not generate a response to quiet actions
                     self.logger.debug("Action is quiet, skipping response generation")
                     return

--- a/vocode/streaming/agent/action_agent.py
+++ b/vocode/streaming/agent/action_agent.py
@@ -68,6 +68,10 @@ class ActionAgent(BaseAgent[ActionAgentConfig]):
                     action_output=agent_input.action_output,
                     conversation_id=agent_input.conversation_id,
                 )
+                if agent_input.quiet_action:
+                    # Do not generate a response to quiet actions
+                    self.logger.debug("Action is quiet, skipping response generation")
+                    return
             else:
                 raise ValueError("Invalid AgentInput type")
 

--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -50,7 +50,7 @@ class TranscriptionAgentInput(AgentInput, type=AgentInputType.TRANSCRIPTION.valu
 
 class ActionResultAgentInput(AgentInput, type=AgentInputType.ACTION_RESULT.value):
     action_output: ActionOutput
-    quiet_action: bool = False
+    is_quiet: bool = False
 
 
 class AgentResponseType(str, Enum):

--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -50,6 +50,7 @@ class TranscriptionAgentInput(AgentInput, type=AgentInputType.TRANSCRIPTION.valu
 
 class ActionResultAgentInput(AgentInput, type=AgentInputType.ACTION_RESULT.value):
     action_output: ActionOutput
+    quiet_action: bool = False
 
 
 class AgentResponseType(str, Enum):


### PR DESCRIPTION
Setting `quiet=True` on an action will perform the action and add it (and its results) to the transcript. However, once the results are added, OpenAI will not be queried to generate a response. Setting `quiet=False` will send a request to OpenAI to generate a response once the action is complete.