### PR TITLE
Add username and password to redis config

### DIFF
--- a/vocode/streaming/telephony/config_manager/redis_config_manager.py
+++ b/vocode/streaming/telephony/config_manager/redis_config_manager.py
@@ -14,6 +14,8 @@ class RedisConfigManager(BaseConfigManager):
         self.redis: Redis = Redis(
             host=os.environ.get("REDISHOST", "localhost"),
             port=int(os.environ.get("REDISPORT", 6379)),
+            username=os.environ.get("REDISUSER", None),
+            password=os.environ.get("REDISPASSWORD", None),
             db=0,
             decode_responses=True,
         )


### PR DESCRIPTION
Just adding it so that I don't have to create a custom class in order to add these environment variables. Think it was discussed in the Discord to add this as well a while back. 