### PR TITLE
Support telephony call recordings in Twilio

### DIFF
--- a/vocode/streaming/telephony/conversation/twilio_call.py
+++ b/vocode/streaming/telephony/conversation/twilio_call.py
@@ -85,7 +85,12 @@ class TwilioCall(Call[TwilioOutputDevice]):
     async def attach_ws_and_start(self, ws: WebSocket):
         super().attach_ws(ws)
 
-        twilio_call = self.telephony_client.twilio_client.calls(self.twilio_sid).fetch()
+        twilio_call_ref = self.telephony_client.twilio_client.calls(self.twilio_sid)
+        twilio_call = twilio_call_ref.fetch()
+
+        if self.twilio_config.record:
+            recording = twilio_call_ref.recordings.create()
+            self.logger.info(f"Recording: {recording.sid}")
 
         if twilio_call.answered_by in ("machine_start", "fax"):
             self.logger.info(f"Call answered by {twilio_call.answered_by}")


### PR DESCRIPTION
Based on the Twilio [Recording docs](https://www.twilio.com/docs/voice/api/recording?code-sample=code-create-recording-on-a-live-call&code-language=Python&code-sdk-version=8.x#linkcode) these change allows to start recording the live calls if the `record` is set to `True` in the `TwilioConfig`.