### PR TITLE
Fix rime synth

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -134,11 +134,13 @@ class ElevenLabsSynthesizerConfig(
 RIME_DEFAULT_SPEAKER = "young_male_unmarked-1"
 RIME_DEFAULT_SAMPLE_RATE = 22050
 RIME_DEFAULT_BASE_URL = "https://rjmopratfrdjgmfmaios.functions.supabase.co/rime-tts"
+RIME_DEFAULT_USE_NEW_FORMAT = False
 
 class RimeSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.RIME.value):
     speaker: str = RIME_DEFAULT_SPEAKER
     sampling_rate: int = RIME_DEFAULT_SAMPLE_RATE
     base_url: str = RIME_DEFAULT_BASE_URL
+    use_new_format: bool = RIME_DEFAULT_USE_NEW_FORMAT
 
 
 

--- a/vocode/streaming/synthesizer/rime_synthesizer.py
+++ b/vocode/streaming/synthesizer/rime_synthesizer.py
@@ -36,6 +36,7 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         self.speaker = synthesizer_config.speaker
         self.sampling_rate = synthesizer_config.sampling_rate
         self.base_url = synthesizer_config.base_url
+        self.use_new_format = synthesizer_config.use_new_body
 
     async def create_speech(
         self,
@@ -47,13 +48,20 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-
+        
         body = {
-            "inputs": {
-                "text": message.text,
-                "speaker": self.speaker,
-                "samplingRate": self.sampling_rate
-            }
+            "text": message.text,
+            "speaker": speaker,
+            "samplingRate": sampling_rate
+        }
+
+        if self.use_new_format:
+            body = {
+                "inputs": {
+                    "text": message.text,
+                    "speaker": self.speaker,
+                    "samplingRate": self.sampling_rate
+                }
         }
 
         create_speech_span = tracer.start_span(

--- a/vocode/streaming/synthesizer/rime_synthesizer.py
+++ b/vocode/streaming/synthesizer/rime_synthesizer.py
@@ -51,8 +51,8 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         
         body = {
             "text": message.text,
-            "speaker": speaker,
-            "samplingRate": sampling_rate
+            "speaker": self.speaker,
+            "samplingRate": self.sampling_rate
         }
 
         if self.use_new_format:

--- a/vocode/streaming/synthesizer/rime_synthesizer.py
+++ b/vocode/streaming/synthesizer/rime_synthesizer.py
@@ -49,10 +49,13 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         }
 
         body = {
-            "text": message.text,
-            "speaker": self.speaker,
-            "samplingRate": self.sampling_rate
+            "inputs": {
+                "text": message.text,
+                "speaker": self.speaker,
+                "samplingRate": self.sampling_rate
+            }
         }
+
         create_speech_span = tracer.start_span(
             f"synthesizer.{SynthesizerType.RIME.value.split('_', 1)[-1]}.create_total",
         )

--- a/vocode/streaming/synthesizer/rime_synthesizer.py
+++ b/vocode/streaming/synthesizer/rime_synthesizer.py
@@ -36,7 +36,7 @@ class RimeSynthesizer(BaseSynthesizer[RimeSynthesizerConfig]):
         self.speaker = synthesizer_config.speaker
         self.sampling_rate = synthesizer_config.sampling_rate
         self.base_url = synthesizer_config.base_url
-        self.use_new_format = synthesizer_config.use_new_body
+        self.use_new_format = synthesizer_config.use_new_format
 
     async def create_speech(
         self,


### PR DESCRIPTION
Issue:
The new Rime synthesizer endpoint encases the body in an "inputs" object which was not there before. 

Fix:
Carefully port curl request to python without breaking changes.

Going off of the sample from Rime dev:

```
curl URL \
-X POST \
-d '{"inputs":{"text": "I really listening to new music.", "speaker": "young_f_unmarked-5", "samplingRate": 8000}}' \
-H "Authorization: Bearer XXX" \
-H "Content-Type: application/json"
```

Added support for the "inputs" encasement of the body. To maintain backwards compatibility, I also added a flag which by default uses the original formatting.