### PR TITLE
Bot goodbye detection

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -311,6 +311,20 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.conversation.transcript.update_last_bot_message_on_cut_off(
                         message_sent
                     )
+                if self.conversation.agent.agent_config.end_conversation_on_goodbye:
+                    goodbye_detected_task = (
+                        self.conversation.agent.create_goodbye_detection_task(
+                            message_sent
+                        )
+                    )
+                    try:
+                        if await asyncio.wait_for(goodbye_detected_task, 0.1):
+                            self.conversation.logger.debug(
+                                "Agent said goodbye, ending call"
+                            )
+                            self.conversation.terminate()
+                    except asyncio.TimeoutError:
+                        pass
             except asyncio.CancelledError:
                 pass
 


### PR DESCRIPTION
This PR is intended to supersede #191

While there is a builtin mechanism for agents to end conversation (by placing AgentResponseStop) in the queue, this doesn't work well in practice given that the queues are handled asynchronously.

The agent will generate the output and immediately hang up before the synthesis stream is completed (i.e. the agent will generate "goodbye" and then hang up before it gets a chance to say it).

Therefore this PR detects bot goodbyes AFTER synthesis has been completed.