### PR TITLE
Use 'bullseye' Debian version instead of unspecified one

### DIFF
--- a/apps/client_backend/Dockerfile
+++ b/apps/client_backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-bullseye
 
 # get portaudio and ffmpeg
 RUN apt-get update \


### PR DESCRIPTION
This change is solving #262 

Debian 12 "Bookworm" was released in early June, which was picked up by python docker image and as a result it broke Azure client.

This change would specify precise version of Debian, which is a good practice anyway. After the issue is solved version could be upgraded to 12.

Running in the container:
Before:
```
# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

# openssl version
OpenSSL 3.0.9 30 May 2023 (Library: OpenSSL 3.0.9 30 May 2023)
```

After:
```
# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

# openssl version
OpenSSL 1.1.1n  15 Mar 2022
```
