### PR TITLE
allow ConversationRouter endpoint to be configured

### DIFF
--- a/vocode/streaming/client_backend/conversation.py
+++ b/vocode/streaming/client_backend/conversation.py
@@ -31,6 +31,8 @@ from vocode.streaming.models.events import Event, EventType
 from vocode.streaming.models.transcript import TranscriptEvent
 from vocode.streaming.utils import events_manager
 
+BASE_CONVERSATION_ENDPOINT = "/conversation"
+
 
 class ConversationRouter(BaseRouter):
     def __init__(
@@ -52,7 +54,7 @@ class ConversationRouter(BaseRouter):
             )
         ),
         logger: Optional[logging.Logger] = None,
-        conversation_endpoint = "/conversation"
+        conversation_endpoint: str = BASE_CONVERSATION_ENDPOINT,
     ):
         super().__init__()
         self.transcriber_thunk = transcriber_thunk
@@ -76,7 +78,9 @@ class ConversationRouter(BaseRouter):
             agent=self.agent,
             synthesizer=synthesizer,
             conversation_id=start_message.conversation_id,
-            events_manager=TranscriptEventManager(output_device, self.logger) if start_message.subscribe_transcript else None,
+            events_manager=TranscriptEventManager(output_device, self.logger)
+            if start_message.subscribe_transcript
+            else None,
             logger=self.logger,
         )
 
@@ -107,8 +111,13 @@ class ConversationRouter(BaseRouter):
     def get_router(self) -> APIRouter:
         return self.router
 
+
 class TranscriptEventManager(events_manager.EventsManager):
-    def __init__(self, output_device: WebsocketOutputDevice, logger: Optional[logging.Logger] = None):
+    def __init__(
+        self,
+        output_device: WebsocketOutputDevice,
+        logger: Optional[logging.Logger] = None,
+    ):
         super().__init__(subscriptions=[EventType.TRANSCRIPT])
         self.output_device = output_device
         self.logger = logger or logging.getLogger(__name__)

--- a/vocode/streaming/client_backend/conversation.py
+++ b/vocode/streaming/client_backend/conversation.py
@@ -52,6 +52,7 @@ class ConversationRouter(BaseRouter):
             )
         ),
         logger: Optional[logging.Logger] = None,
+        conversation_endpoint = "/conversation"
     ):
         super().__init__()
         self.transcriber_thunk = transcriber_thunk
@@ -59,7 +60,7 @@ class ConversationRouter(BaseRouter):
         self.synthesizer_thunk = synthesizer_thunk
         self.logger = logger or logging.getLogger(__name__)
         self.router = APIRouter()
-        self.router.websocket("/conversation")(self.conversation)
+        self.router.websocket(conversation_endpoint)(self.conversation)
 
     def get_conversation(
         self,


### PR DESCRIPTION
It's ideal that this should be configurable.

My use case in particular is to support multiple conversation endpoints.
