### PR TITLE
Add extra_params to TwilioClient

### DIFF
--- a/vocode/streaming/models/telephony.py
+++ b/vocode/streaming/models/telephony.py
@@ -25,7 +25,7 @@ class TwilioConfig(BaseModel):
     account_sid: str
     auth_token: str
     record: bool = False
-    extra_params: Optional[Dict[str, Any]] = None
+    extra_params: Optional[Dict[str, Any]] = {}
 
 
 class VonageConfig(BaseModel):

--- a/vocode/streaming/models/telephony.py
+++ b/vocode/streaming/models/telephony.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional
 from vocode.streaming.models.audio_encoding import AudioEncoding
 from vocode.streaming.models.model import BaseModel, TypedModel
 from vocode.streaming.models.agent import AgentConfig
@@ -25,6 +25,7 @@ class TwilioConfig(BaseModel):
     account_sid: str
     auth_token: str
     record: bool = False
+    extra_params: Optional[Dict[str, Any]] = None
 
 
 class VonageConfig(BaseModel):

--- a/vocode/streaming/telephony/client/twilio_client.py
+++ b/vocode/streaming/telephony/client/twilio_client.py
@@ -39,6 +39,7 @@ class TwilioClient(BaseTelephonyClient):
             from_=from_phone,
             send_digits=digits,
             record=record,
+            **self.get_telephony_config().extra_params,
         )
         return twilio_call.sid
 


### PR DESCRIPTION
Direct replacement for https://github.com/vocodedev/vocode-python/pull/271

Pass extra args into Twilio call creation via TwilioConfig