### PR TITLE
Make 'telephony_client.end_call' async

### DIFF
--- a/vocode/streaming/telephony/client/base_telephony_client.py
+++ b/vocode/streaming/telephony/client/base_telephony_client.py
@@ -20,7 +20,7 @@ class BaseTelephonyClient:
     ) -> str:  # identifier of the call on the telephony provider
         raise NotImplementedError
 
-    def end_call(self, id) -> bool:
+    async def end_call(self, id) -> bool:
         raise NotImplementedError
 
     def validate_outbound_call(

--- a/vocode/streaming/telephony/client/twilio_client.py
+++ b/vocode/streaming/telephony/client/twilio_client.py
@@ -47,7 +47,8 @@ class TwilioClient(BaseTelephonyClient):
             base_url=self.base_url, call_id=conversation_id
         )
 
-    def end_call(self, twilio_sid):
+    async def end_call(self, twilio_sid):
+        # TODO: Make this async. This is blocking.
         response = self.twilio_client.calls(twilio_sid).update(status="completed")
         return response.status == "completed"
 

--- a/vocode/streaming/telephony/client/vonage_client.py
+++ b/vocode/streaming/telephony/client/vonage_client.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import aiohttp
 from vocode.streaming.models.telephony import VonageConfig
 from vocode.streaming.telephony.client.base_telephony_client import BaseTelephonyClient
 import vonage
@@ -45,26 +46,40 @@ class VonageClient(BaseTelephonyClient):
     def create_call_ncco(base_url, conversation_id, record):
         ncco = []
         if record:
-            ncco.append({
-                "action": "record",
-                "eventUrl": [f"https://{base_url}/recordings/{conversation_id}"]
-            })
-        ncco.append({
-            "action": "connect",
-            "endpoint": [
+            ncco.append(
                 {
-                    "type": "websocket",
-                    "uri": f"wss://{base_url}/connect_call/{conversation_id}",
-                    "content-type": VONAGE_CONTENT_TYPE,
-                    "headers": {},
+                    "action": "record",
+                    "eventUrl": [f"https://{base_url}/recordings/{conversation_id}"],
                 }
-            ],
-        })
+            )
+        ncco.append(
+            {
+                "action": "connect",
+                "endpoint": [
+                    {
+                        "type": "websocket",
+                        "uri": f"wss://{base_url}/connect_call/{conversation_id}",
+                        "content-type": VONAGE_CONTENT_TYPE,
+                        "headers": {},
+                    }
+                ],
+            }
+        )
         return ncco
 
-    def end_call(self, id) -> bool:
-        # TODO(EPD-186): return True if the call was ended successfully
-        self.voice.update_call(uuid=id, action="hangup")
+    async def end_call(self, id) -> bool:
+        async with aiohttp.ClientSession() as session:
+            async with session.put(
+                f"https://api.nexmo.com/v1/calls/{id}",
+                json={"action": "hangup"},
+                headers={
+                    "Authorization": f"Bearer {self.client._generate_application_jwt().decode()}"
+                },
+            ) as response:
+                if not response.ok:
+                    raise RuntimeError(
+                        f"Failed to end call: {response.status} {response.reason}"
+                    )
         return True
 
     # TODO(EPD-186)

--- a/vocode/streaming/telephony/conversation/outbound_call.py
+++ b/vocode/streaming/telephony/conversation/outbound_call.py
@@ -148,5 +148,5 @@ class OutboundCall:
             raise ValueError("Unknown telephony client")
         await self.config_manager.save_config(self.conversation_id, call_config)
 
-    def end(self):
-        return self.telephony_client.end_call(self.telephony_id)
+    async def end(self):
+        return await self.telephony_client.end_call(self.telephony_id)

--- a/vocode/streaming/telephony/conversation/twilio_call.py
+++ b/vocode/streaming/telephony/conversation/twilio_call.py
@@ -1,3 +1,4 @@
+import asyncio
 from fastapi import WebSocket
 import base64
 from enum import Enum
@@ -152,4 +153,5 @@ class TwilioCall(Call[TwilioOutputDevice]):
 
     def mark_terminated(self):
         super().mark_terminated()
-        self.telephony_client.end_call(self.twilio_sid)
+        asyncio.create_task(self.telephony_client.end_call(self.twilio_sid))
+

--- a/vocode/streaming/telephony/server/base.py
+++ b/vocode/streaming/telephony/server/base.py
@@ -184,12 +184,12 @@ class TelephonyServer:
             telephony_client = TwilioClient(
                 base_url=self.base_url, twilio_config=call_config.twilio_config
             )
-            telephony_client.end_call(call_config.twilio_sid)
+            await telephony_client.end_call(call_config.twilio_sid)
         elif isinstance(call_config, VonageCallConfig):
             telephony_client = VonageClient(
                 base_url=self.base_url, vonage_config=call_config.vonage_config
             )
-            telephony_client.end_call(call_config.vonage_uuid)
+            await telephony_client.end_call(call_config.vonage_uuid)
         return {"id": conversation_id}
 
     def get_router(self) -> APIRouter:


### PR DESCRIPTION
This is for Vonage only. The Twilio `end_call` function is now and async function that runs synchronous code and is thus blocking.