### PR TITLE
Multiple agents per router

### DIFF
--- a/apps/client_backend/main.py
+++ b/apps/client_backend/main.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 conversation_router = ConversationRouter(
-    agent=ChatGPTAgent(
+    agent_thunk=lambda: ChatGPTAgent(
         ChatGPTAgentConfig(
             initial_message=BaseMessage(text="Hello!"),
             prompt_preamble="Have a pleasant conversation about life",

--- a/vocode/streaming/client_backend/conversation.py
+++ b/vocode/streaming/client_backend/conversation.py
@@ -37,7 +37,7 @@ BASE_CONVERSATION_ENDPOINT = "/conversation"
 class ConversationRouter(BaseRouter):
     def __init__(
         self,
-        agent: BaseAgent,
+        agent_thunk: Callable[[], BaseAgent],
         transcriber_thunk: Callable[
             [InputAudioConfig], BaseTranscriber
         ] = lambda input_audio_config: DeepgramTranscriber(
@@ -58,7 +58,7 @@ class ConversationRouter(BaseRouter):
     ):
         super().__init__()
         self.transcriber_thunk = transcriber_thunk
-        self.agent = agent
+        self.agent_thunk = agent_thunk
         self.synthesizer_thunk = synthesizer_thunk
         self.logger = logger or logging.getLogger(__name__)
         self.router = APIRouter()
@@ -75,7 +75,7 @@ class ConversationRouter(BaseRouter):
         return StreamingConversation(
             output_device=output_device,
             transcriber=transcriber,
-            agent=self.agent,
+            agent=self.agent_thunk(),
             synthesizer=synthesizer,
             conversation_id=start_message.conversation_id,
             events_manager=TranscriptEventManager(output_device, self.logger)


### PR DESCRIPTION
Change ConversationRouter so it takes an `agent_thunk` argument instead of `agent`, to instantiate a new agent for each conversation