### PR TITLE
Passing conversation_id to synthesizer thunk for customization

### DIFF
--- a/vocode/streaming/client_backend/conversation.py
+++ b/vocode/streaming/client_backend/conversation.py
@@ -70,7 +70,7 @@ class ConversationRouter(BaseRouter):
         start_message: AudioConfigStartMessage,
     ) -> StreamingConversation:
         transcriber = self.transcriber_thunk(start_message.input_audio_config)
-        synthesizer = self.synthesizer_thunk(start_message.output_audio_config)
+        synthesizer = self.synthesizer_thunk(start_message.output_audio_config, start_message.conversation_id)
         synthesizer.synthesizer_config.should_encode_as_wav = True
         return StreamingConversation(
             output_device=output_device,

--- a/vocode/streaming/client_backend/conversation.py
+++ b/vocode/streaming/client_backend/conversation.py
@@ -47,7 +47,7 @@ class ConversationRouter(BaseRouter):
             )
         ),
         synthesizer_thunk: Callable[
-            [OutputAudioConfig], BaseSynthesizer
+            [OutputAudioConfig, Optional[str]], BaseSynthesizer
         ] = lambda output_audio_config: AzureSynthesizer(
             AzureSynthesizerConfig.from_output_audio_config(
                 output_audio_config=output_audio_config


### PR DESCRIPTION
Having access to the conversation_id from within the synthesizer_thunk would allow us to fetch details about the conversation ( from a db for example ) and customize the synthesizer based on that. 

My use case : 
In my web application, users can pick a character ( from a list of character ) to have a conversation with. 
i.e I need to pass in a different `voice_id` based on what character the user picks ( I'm using eleven labs ). This information is stored in the db associated with the conversation_id and need to be fetched from within the synthesizer thunk to be able to set it. 

Alternate Solution: 
Another solution would be to take in the voice_id as part of the output_audio_config. 

