### PR TITLE
Allow responses from actions to be sent

### DIFF
--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -242,8 +242,17 @@ class RespondAgent(BaseAgent[AgentConfigType]):
         assert self.transcript is not None
         try:
             agent_input = item.payload
-            if isinstance(agent_input, ActionResultAgentInput):
+            if isinstance(agent_input, TranscriptionAgentInput):
+                transcription = typing.cast(
+                    TranscriptionAgentInput, agent_input
+                ).transcription
+                self.transcript.add_human_message(
+                    text=transcription.message,
+                    conversation_id=agent_input.conversation_id,
+                )
+            elif isinstance(agent_input, ActionResultAgentInput):
                 self.transcript.add_action_finish_log(
+                    action_input=agent_input.action_input,
                     action_output=agent_input.action_output,
                     conversation_id=agent_input.conversation_id,
                 )
@@ -251,15 +260,14 @@ class RespondAgent(BaseAgent[AgentConfigType]):
                     # Do not generate a response to quiet actions
                     self.logger.debug("Action is quiet, skipping response generation")
                     return
-            if agent_input.type != AgentInputType.TRANSCRIPTION:
-                return
-            transcription = typing.cast(
-                TranscriptionAgentInput, agent_input
-            ).transcription
-            self.transcript.add_human_message(
-                text=transcription.message,
-                conversation_id=agent_input.conversation_id,
-            )
+                transcription = Transcription(
+                    message=agent_input.action_output.response.json(),
+                    confidence=1.0,
+                    is_final=True,
+                )
+            else:
+                raise ValueError("Invalid AgentInput type")
+
             goodbye_detected_task = None
             if self.agent_config.end_conversation_on_goodbye:
                 goodbye_detected_task = self.create_goodbye_detection_task(


### PR DESCRIPTION
Fixes an issue where the action result was added to the transcript but no response would be generated even if `is_quiet` was false. This issue was introduced in #260. This is a similar fix to #290 but it uses the old code from the original implementation in #245.