### PR TITLE
Add support for multiple languages for Azure transcriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ credentials.json
 **/call_transcripts/*.txt
 benchmark_results/
 private.key
-.vscode/settings.json
-.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ credentials.json
 **/call_transcripts/*.txt
 benchmark_results/
 private.key
+.vscode/settings.json
+.gitignore

--- a/vocode/streaming/models/transcriber.py
+++ b/vocode/streaming/models/transcriber.py
@@ -13,6 +13,8 @@ from vocode.streaming.telephony.constants import (
 from .audio_encoding import AudioEncoding
 from .model import TypedModel
 
+AZURE_DEFAULT_LANGUAGE = "en-US"
+
 
 class TranscriberType(str, Enum):
     BASE = "transcriber_base"
@@ -118,17 +120,9 @@ class GoogleTranscriberConfig(TranscriberConfig, type=TranscriberType.GOOGLE.val
     language_code: str = "en-US"
 
 
-from typing import Union
-
 class AzureTranscriberConfig(TranscriberConfig, type=TranscriberType.AZURE.value):
-    language: Optional[str] = None
+    language: str = AZURE_DEFAULT_LANGUAGE
     candidate_languages: Optional[List[str]] = None
-
-    @validator("language", "candidate_languages")
-    def must_have_a_language(cls, v, values, field):
-        if field == "language" and v is None and values.get("candidate_languages") is None:
-            raise ValueError("Either language or candidate_languages must be set.")
-        return v
 
 
 class AssemblyAITranscriberConfig(

--- a/vocode/streaming/models/transcriber.py
+++ b/vocode/streaming/models/transcriber.py
@@ -118,8 +118,17 @@ class GoogleTranscriberConfig(TranscriberConfig, type=TranscriberType.GOOGLE.val
     language_code: str = "en-US"
 
 
+from typing import Union
+
 class AzureTranscriberConfig(TranscriberConfig, type=TranscriberType.AZURE.value):
-    pass
+    language: Optional[str] = None
+    candidate_languages: Optional[List[str]] = None
+
+    @validator("language", "candidate_languages")
+    def must_have_a_language(cls, v, values, field):
+        if field == "language" and v is None and values.get("candidate_languages") is None:
+            raise ValueError("Either language or candidate_languages must be set.")
+        return v
 
 
 class AssemblyAITranscriberConfig(

--- a/vocode/streaming/transcriber/azure_transcriber.py
+++ b/vocode/streaming/transcriber/azure_transcriber.py
@@ -54,9 +54,18 @@ class AzureTranscriber(BaseThreadAsyncTranscriber[AzureTranscriberConfig]):
             region=getenv("AZURE_SPEECH_REGION"),
         )
 
-        self.speech = speechsdk.SpeechRecognizer(
-            speech_config=speech_config, audio_config=config
-        )
+        if self.transcriber_config.candidate_languages:
+            speech_config.set_property(property_id=speechsdk.PropertyId.SpeechServiceConnection_LanguageIdMode, value='Continuous')
+            auto_detect_source_language_config = speechsdk.languageconfig.AutoDetectSourceLanguageConfig(
+                languages=self.transcriber_config.candidate_languages
+            )
+            self.speech = speechsdk.SpeechRecognizer(
+                speech_config=speech_config, auto_detect_source_language_config=auto_detect_source_language_config, audio_config=config
+            )
+        else:
+            self.speech = speechsdk.SpeechRecognizer(
+                speech_config=speech_config, language=self.transcriber_config.language, audio_config=config
+            )
 
         self._ended = False
         self.is_ready = False


### PR DESCRIPTION
Added language support for Azure transcriber #294 

----------------

Example implementations: `language="de-DE"` or `candidate_languages=["en-US", "de-DE", "zh-CN", "es-MX"]`

`candidate_languages` will always override `language`

Note that less 'advanced' LLMs (e.g. gpt-3.5-turbo), even despite prompting, will output their response in whatever input language they're given. This raises other issues of the synthesizer being unable to produce output if it is set to only one hardcoded/default language