### PR TITLE
[DRAFT] Fix typographical error in telephony documentation

### DIFF
--- a/docs/telephony.mdx
+++ b/docs/telephony.mdx
@@ -121,7 +121,7 @@ uvicorn main:app --port 3000
 Make sure the server we just set up is already running. Then, in `outbound_call.py`
 
 1. Replace the `to_phone` with the number you want to call and the `from_phone` with the number you want to call from.
-   In order to make a call from the `to_phone`, you must have access to it via Twilio (either a number purchased via Twilio or verify the caller ID).
+   In order to make a call from the `from_phone`, you must have access to it via Twilio (either a number purchased via Twilio or verify the caller ID).
 
 > Note: To ensure legal compliance with robocall regulations in California, the following code snippet from the [Vocode library](https://github.com/vocodedev/vocode-python/blob/main/vocode/streaming/telephony/conversation/outbound_call.py#L83-L96) utilizes Twilio Line Intelligence to check if calls are made to mobile phones: For Canadian phone numbers, the Twilio Lookup API may not return carrier data due to the Canadian Local Number Portability Consortium (CLNPC) requirements. More information on this issue can be found in the [Twilio Support Article](https://support.twilio.com/hc/en-us/articles/360004563433-Twilio-Lookup-API-is-Not-Returning-Carrier-Data-for-Canadian-Phone-Numbers).
 


### PR DESCRIPTION
This PR was copied from sweepai-dev#4 and generated by [Sweep](https://github.com/sweepai/sweep).
Resolves #258.

---
## Description
This PR fixes a typographical error in the telephony documentation. The sentence "In order to make a call from the to_phone, you must have access to it via Twilio (either a number purchased via Twilio or verify the caller ID)" has been corrected to "In order to make a call from the from_phone, you must have access to it via Twilio (either a number purchased via Twilio or verify the caller ID)". This change ensures that the documentation accurately reflects the functionality of the code.

## Summary of Changes
- Modified the `docs/telephony.mdx` file to correct the typographical error in the documentation.
- Replaced the word "to_phone" with "from_phone" in the sentence "In order to make a call from the to_phone, you must have access to it via Twilio (either a number purchased via Twilio or verify the caller ID)".

Please review and merge this PR. Thank you!

Fixes #258.

To checkout this PR branch, run the following command in your terminal:
```zsh
git checkout sweep/fix-typo-telephony-docs
```