### PR TITLE
[DRAFT] Add keyword-based interrupts

### DIFF
--- a/vocode/streaming/models/agent.py
+++ b/vocode/streaming/models/agent.py
@@ -70,6 +70,7 @@ class AgentConfig(TypedModel, type=AgentType.BASE.value):
     webhook_config: Optional[WebhookConfig] = None
     track_bot_sentiment: bool = False
     actions: Optional[List[ActionConfig]] = None
+    wake_up_word: Optional[str] = None
 
 
 class CutOffResponse(BaseModel):

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -112,6 +112,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.conversation.transcriber.get_transcriber_config().min_interrupt_confidence
                     or 0
                 )
+                and self.conversation.agent.get_agent_config().wake_up_word in transcription.message
             ):
                 self.conversation.current_transcription_is_interrupt = (
                     self.conversation.broadcast_interrupt()


### PR DESCRIPTION
This PR was copied from sweepai-dev#10 and generated by [Sweep](https://github.com/sweepai/sweep).
Resolves #73.

---
## Description
This PR adds support for keyword-based interrupts in the `vocode-python` repository. Currently, the bot gets interrupted when the human starts speaking. With this change, the bot will only get interrupted if the transcribed text contains a specific wake-up word.

## Summary of Changes
- Added a new configuration parameter `wake_up_word` in the `AgentConfig` class. This parameter allows the user to specify the wake-up word that should interrupt the bot. The default value is `None`.
- Modified the `TranscriptionsWorker` class in the `StreamingConversation` module. The `process` method now checks if the transcribed text contains the wake-up word before broadcasting an interrupt.

Please review and merge this PR to enable keyword-based interrupts in the `vocode-python` repository.

Fixes #73.

To checkout this PR branch, run the following command in your terminal:
```zsh
git checkout sweep/feature/keyword-based-interrupts
```