### PR TITLE
allows action to wait on user message

### DIFF
--- a/vocode/streaming/action/base_action.py
+++ b/vocode/streaming/action/base_action.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict, Generic, Type, TypeVar, TYPE_CHECKING
 from vocode.streaming.action.utils import exclude_keys_recursive
 from vocode.streaming.models.actions import (
@@ -55,7 +56,9 @@ class BaseAction(Generic[ActionConfigType, ParametersType, ResponseType]):
             parameters_schema["properties"][
                 "user_message"
             ] = self._user_message_param_info()
-            parameters_schema["required"].append("user_message")
+            required = parameters_schema.get("required", [])
+            required.append("user_message")
+            parameters_schema["required"] = required
 
         return {
             "name": self.action_config.type,
@@ -67,6 +70,7 @@ class BaseAction(Generic[ActionConfigType, ParametersType, ResponseType]):
         self,
         conversation_id: str,
         params: Dict[str, Any],
+        user_message_tracker: asyncio.Event,
     ) -> ActionInput[ParametersType]:
         if "user_message" in params:
             del params["user_message"]
@@ -74,6 +78,7 @@ class BaseAction(Generic[ActionConfigType, ParametersType, ResponseType]):
             action_config=self.action_config,
             conversation_id=conversation_id,
             params=self.parameters_type(**params),
+            user_message_tracker=user_message_tracker,
         )
 
     def _user_message_param_info(self):

--- a/vocode/streaming/action/phone_call_action.py
+++ b/vocode/streaming/action/phone_call_action.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Dict, Any
 from vocode.streaming.action.base_action import ActionConfigType, BaseAction
 from vocode.streaming.models.actions import (
@@ -12,7 +13,11 @@ from vocode.streaming.models.actions import (
 
 class VonagePhoneCallAction(BaseAction[ActionConfigType, ParametersType, ResponseType]):
     def create_phone_call_action_input(
-        self, conversation_id: str, params: Dict[str, Any], vonage_uuid: str
+        self,
+        conversation_id: str,
+        params: Dict[str, Any],
+        vonage_uuid: str,
+        user_message_tracker: asyncio.Event,
     ) -> VonagePhoneCallActionInput[ParametersType]:
         if "user_message" in params:
             del params["user_message"]
@@ -21,6 +26,7 @@ class VonagePhoneCallAction(BaseAction[ActionConfigType, ParametersType, Respons
             conversation_id=conversation_id,
             params=self.parameters_type(**params),
             vonage_uuid=vonage_uuid,
+            user_message_tracker=user_message_tracker,
         )
 
     def get_vonage_uuid(self, action_input: ActionInput[ParametersType]) -> str:
@@ -30,7 +36,11 @@ class VonagePhoneCallAction(BaseAction[ActionConfigType, ParametersType, Respons
 
 class TwilioPhoneCallAction(BaseAction[ActionConfigType, ParametersType, ResponseType]):
     def create_phone_call_action_input(
-        self, conversation_id: str, params: Dict[str, Any], twilio_sid: str
+        self,
+        conversation_id: str,
+        params: Dict[str, Any],
+        twilio_sid: str,
+        user_message_tracker: asyncio.Event,
     ) -> TwilioPhoneCallActionInput[ParametersType]:
         if "user_message" in params:
             del params["user_message"]
@@ -39,6 +49,7 @@ class TwilioPhoneCallAction(BaseAction[ActionConfigType, ParametersType, Respons
             conversation_id=conversation_id,
             params=self.parameters_type(**params),
             twilio_sid=twilio_sid,
+            user_message_tracker=user_message_tracker,
         )
 
     def get_twilio_sid(self, action_input: ActionInput[ParametersType]) -> str:

--- a/vocode/streaming/models/actions.py
+++ b/vocode/streaming/models/actions.py
@@ -1,3 +1,4 @@
+import asyncio
 from enum import Enum
 from typing import Generic, TypeVar
 from pydantic import BaseModel
@@ -20,6 +21,10 @@ class ActionInput(BaseModel, Generic[ParametersType]):
     action_config: ActionConfig
     conversation_id: str
     params: ParametersType
+    user_message_tracker: asyncio.Event
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class FunctionFragment(BaseModel):


### PR DESCRIPTION
passes a `user_message_tracker` (the `asyncio.Event` that is set once the agent response is finished) into the `ActionInput`. now, actions can wait on the user message before executing the action (or not)