### PR TITLE
Fix default tier and model in DeepgramTranscriberConfig

### DIFF
--- a/vocode/streaming/models/transcriber.py
+++ b/vocode/streaming/models/transcriber.py
@@ -105,8 +105,8 @@ class TranscriberConfig(TypedModel, type=TranscriberType.BASE.value):
 
 class DeepgramTranscriberConfig(TranscriberConfig, type=TranscriberType.DEEPGRAM.value):
     language: Optional[str] = None
-    model: Optional[str] = "nova"
-    tier: Optional[str] = None
+    model: Optional[str] = "phonecall"
+    tier: Optional[str] = "nova"
     version: Optional[str] = None
     keywords: Optional[list] = None
 


### PR DESCRIPTION
The default value is incorrect in the DeepgramTranscriberConfig.

`nova` is a tier, not a model. This is also being used in `vocode-python/vocode/streaming/models/telephony.py` with those values.