### PR TITLE
Allow voice_engine configuration for PlayHt synthesizer

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -171,6 +171,7 @@ class PlayHtSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.PLAY_HT.va
     speed: Optional[int] = None
     seed: Optional[int] = None
     temperature: Optional[int] = None
+    voice_engine_id: Optional[str] = None
     voice_id: str = PLAYHT_DEFAULT_VOICE_ID
     experimental_streaming: bool = False
 

--- a/vocode/streaming/synthesizer/play_ht_synthesizer.py
+++ b/vocode/streaming/synthesizer/play_ht_synthesizer.py
@@ -64,6 +64,8 @@ class PlayHtSynthesizer(BaseSynthesizer[PlayHtSynthesizerConfig]):
             body["seed"] = self.synthesizer_config.seed
         if self.synthesizer_config.temperature:
             body["temperature"] = self.synthesizer_config.temperature
+        if self.synthesizer_config.voice_engine_id:
+            body["voice_engine_id"] = self.synthesizer_config.voice_engine_id
 
         create_speech_span = tracer.start_span(
             f"synthesizer.{SynthesizerType.PLAY_HT.value.split('_', 1)[-1]}.create_total",


### PR DESCRIPTION
With the release of PlayHT2.0-turbo there's now a meaningful choice between audio quality and latency. This change exposes a param to control this.
(https://docs.play.ht/reference/supported-voice-models for more background)