### PR TITLE
fixing event manager so it can clear the queue

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1506,6 +1506,13 @@
             "type": "number",
             "title": "Initial Message Delay",
             "default": 0.0
+          },
+          "openai_model_name_override": {
+            "type": "string",
+            "title": "Openai Model Name Override"
+          },
+          "openai_account_connection": {
+            "$ref": "#/components/schemas/OpenAIAccountConnection"
           }
         },
         "type": "object",
@@ -1619,6 +1626,17 @@
             "type": "number",
             "title": "Initial Message Delay",
             "default": 0.0
+          },
+          "openai_model_name_override": {
+            "type": "string",
+            "title": "Openai Model Name Override"
+          },
+          "openai_account_connection": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/OpenAIAccountConnection" },
+              { "type": "string", "format": "uuid" }
+            ],
+            "title": "Openai Account Connection"
           }
         },
         "type": "object",
@@ -1759,6 +1777,21 @@
               { "$ref": "#/components/schemas/Undefined" }
             ],
             "title": "Initial Message Delay"
+          },
+          "openai_model_name_override": {
+            "anyOf": [
+              { "type": "string" },
+              { "$ref": "#/components/schemas/Undefined" }
+            ],
+            "title": "Openai Model Name Override"
+          },
+          "openai_account_connection": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/OpenAIAccountConnection" },
+              { "type": "string", "format": "uuid" },
+              { "$ref": "#/components/schemas/Undefined" }
+            ],
+            "title": "Openai Account Connection"
           }
         },
         "type": "object",
@@ -1912,6 +1945,9 @@
           "run_do_not_call_detection": {
             "type": "boolean",
             "title": "Run Do Not Call Detection"
+          },
+          "telephony_account_connection": {
+            "$ref": "#/components/schemas/TwilioAccountConnection"
           }
         },
         "type": "object",
@@ -2054,6 +2090,17 @@
             "type": "number",
             "title": "Initial Message Delay",
             "default": 0.0
+          },
+          "openai_model_name_override": {
+            "type": "string",
+            "title": "Openai Model Name Override"
+          },
+          "openai_account_connection": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/OpenAIAccountConnection" },
+              { "type": "string", "format": "uuid" }
+            ],
+            "title": "Openai Account Connection"
           }
         },
         "type": "object",
@@ -2416,6 +2463,17 @@
             "type": "number",
             "title": "Initial Message Delay",
             "default": 0.0
+          },
+          "openai_model_name_override": {
+            "type": "string",
+            "title": "Openai Model Name Override"
+          },
+          "openai_account_connection": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/OpenAIAccountConnection" },
+              { "type": "string", "format": "uuid" }
+            ],
+            "title": "Openai Account Connection"
           }
         },
         "type": "object",
@@ -2487,6 +2545,13 @@
           "run_do_not_call_detection": {
             "type": "boolean",
             "title": "Run Do Not Call Detection"
+          },
+          "telephony_account_connection": {
+            "anyOf": [
+              { "type": "string", "format": "uuid" },
+              { "$ref": "#/components/schemas/TwilioAccountConnection" }
+            ],
+            "title": "Telephony Account Connection"
           }
         },
         "type": "object",
@@ -2561,6 +2626,29 @@
         "type": "object",
         "required": ["id", "user_id"],
         "title": "NormalizedPrompt"
+      },
+      "OpenAIAccountConnection": {
+        "properties": {
+          "id": { "type": "string", "format": "uuid", "title": "Id" },
+          "user_id": { "type": "string", "format": "uuid", "title": "User Id" },
+          "type": {
+            "type": "string",
+            "enum": ["account_connection_openai"],
+            "title": "Type"
+          },
+          "credentials": { "$ref": "#/components/schemas/OpenAICredentials" }
+        },
+        "type": "object",
+        "required": ["id", "user_id", "type", "credentials"],
+        "title": "OpenAIAccountConnection"
+      },
+      "OpenAICredentials": {
+        "properties": {
+          "openai_api_key": { "type": "string", "title": "Openai Api Key" }
+        },
+        "type": "object",
+        "required": ["openai_api_key"],
+        "title": "OpenAICredentials"
       },
       "PhoneNumber": {
         "properties": {
@@ -3027,6 +3115,13 @@
       },
       "UpdateNumberRequest": {
         "properties": {
+          "outbound_only": {
+            "anyOf": [
+              { "type": "boolean" },
+              { "$ref": "#/components/schemas/Undefined" }
+            ],
+            "title": "Outbound Only"
+          },
           "label": {
             "anyOf": [
               { "type": "string" },

--- a/tests/streaming/utils/test_events_manager.py
+++ b/tests/streaming/utils/test_events_manager.py
@@ -1,12 +1,8 @@
 import pytest
 import asyncio
 
-from vocode.streaming.models.events import PhoneCallEndedEvent
-from vocode.streaming.utils.events_manager import (
-    EventsManager,
-    Event,
-    EventType,
-)  # Replace 'your_module' with the actual module name
+from vocode.streaming.models.events import PhoneCallEndedEvent, EventType
+from vocode.streaming.utils.events_manager import EventsManager
 
 CONVERSATION_ID = "1"
 

--- a/tests/streaming/utils/test_events_manager.py
+++ b/tests/streaming/utils/test_events_manager.py
@@ -1,0 +1,69 @@
+import pytest
+import asyncio
+
+from vocode.streaming.models.events import PhoneCallEndedEvent
+from vocode.streaming.utils.events_manager import (
+    EventsManager,
+    Event,
+    EventType,
+)  # Replace 'your_module' with the actual module name
+
+CONVERSATION_ID = "1"
+
+
+@pytest.mark.asyncio
+async def test_initialization():
+    manager = EventsManager()
+    assert manager.subscriptions == set()
+    assert isinstance(manager.queue, asyncio.Queue)
+    assert not manager.active
+
+
+@pytest.mark.asyncio
+async def test_publish_event():
+    event = PhoneCallEndedEvent(
+        conversation_id=CONVERSATION_ID, type=EventType.PHONE_CALL_ENDED
+    )  # Replace with actual Event creation
+    manager = EventsManager([EventType.PHONE_CALL_ENDED])
+    manager.publish_event(event)
+    assert not manager.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_default_implementation():
+    event = PhoneCallEndedEvent(
+        conversation_id=CONVERSATION_ID, type=EventType.PHONE_CALL_ENDED
+    )  # Replace with actual Event creation
+    manager = EventsManager([EventType.PHONE_CALL_ENDED])
+    await manager.handle_event(event)
+
+
+@pytest.mark.asyncio
+async def test_start_and_active_loop():
+    event = PhoneCallEndedEvent(
+        conversation_id=CONVERSATION_ID, type=EventType.PHONE_CALL_ENDED
+    )  # Replace with actual Event creation
+    manager = EventsManager([EventType.PHONE_CALL_ENDED])
+    asyncio.create_task(manager.start())
+    manager.publish_event(event)
+    await asyncio.sleep(0.1)
+    manager.active = False
+
+
+@pytest.mark.asyncio
+async def test_flush_method():
+    event = PhoneCallEndedEvent(
+        conversation_id=CONVERSATION_ID, type=EventType.PHONE_CALL_ENDED
+    )
+    manager = EventsManager([EventType.PHONE_CALL_ENDED])
+    for _ in range(5):
+        manager.publish_event(event)
+    await manager.flush(timeout=2)
+    assert manager.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_queue_empty_and_timeout():
+    manager = EventsManager([EventType.TRANSCRIPT])
+    await manager.flush(timeout=0)
+    assert manager.queue.empty()

--- a/vocode/streaming/utils/events_manager.py
+++ b/vocode/streaming/utils/events_manager.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import asyncio
-from typing import List
 
-from vocode.streaming.models.events import Event, EventType
+
+from vocode.streaming.models.events import Event
 
 
 async def flush_event(event):
@@ -11,7 +11,9 @@ async def flush_event(event):
 
 
 class EventsManager:
-    def __init__(self, subscriptions: List[EventType] = []):
+    def __init__(self, subscriptions=None):
+        if subscriptions is None:
+            subscriptions = []
         self.queue: asyncio.Queue[Event] = asyncio.Queue()
         self.subscriptions = set(subscriptions)
         self.active = False
@@ -25,9 +27,9 @@ class EventsManager:
         while self.active:
             try:
                 event = await self.queue.get()
+                await self.handle_event(event)
             except asyncio.QueueEmpty:
                 await asyncio.sleep(1)
-            await self.handle_event(event)
 
     async def handle_event(self, event: Event):
         pass  # Default implementation, can be overridden

--- a/vocode/streaming/utils/events_manager.py
+++ b/vocode/streaming/utils/events_manager.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
-
 import asyncio
 from typing import List
 
 from vocode.streaming.models.events import Event, EventType
 
 
-async def handle_event(event):
+async def flush_event(event):
     if event:
         del event
 
@@ -28,13 +27,16 @@ class EventsManager:
                 event = await self.queue.get()
             except asyncio.QueueEmpty:
                 await asyncio.sleep(1)
-            await handle_event(event)
+            await self.handle_event(event)
+
+    async def handle_event(self, event: Event):
+        pass  # Default implementation, can be overridden
 
     async def flush(self, timeout=30):
         while True:
             try:
                 event = await asyncio.wait_for(self.queue.get(), timeout)
-                await handle_event(event)
+                await flush_event(event)
             except asyncio.TimeoutError:
                 break
             except asyncio.QueueEmpty:


### PR DESCRIPTION
When running telephonyserver, some calls would not terminate appropriately, incurring high cost in Twilio as they could get stuck for 250 minutes even if they lasted 10 seconds. 
This was due to EventsManager not clearing the queue appropriately and stopping Call termination process from completing. 


In the logs it would look like this:

```
  File "/home/ubuntu/venv/lib/python3.10/site-packages/vocode/streaming/streaming_conversation.py", line 687, in terminate
    await self.events_manager.flush()
  File "/home/ubuntu/venv/lib/python3.10/site-packages/vocode/streaming/utils/events_manager.py", line 36, in flush
    await self.handle_event(event)
    TypeError: object NoneType can't be used in 'await' expression
```

![image](https://github.com/vocodedev/vocode-python/assets/5145792/3ed60156-0c93-459b-8448-e5d01d9b2c17)


it seems like futures fixtures messing up how async definition is handled within the class
