### PR TITLE
implement end of utterance detection for AssemblyAI

### DIFF
--- a/vocode/streaming/models/transcriber.py
+++ b/vocode/streaming/models/transcriber.py
@@ -130,6 +130,7 @@ class AssemblyAITranscriberConfig(
 ):
     buffer_size_seconds: float = 0.1
     word_boost: Optional[List[str]] = None
+    end_utterance_silence_threshold: Optional[int] = None
 
 
 class WhisperCPPTranscriberConfig(

--- a/vocode/streaming/models/transcriber.py
+++ b/vocode/streaming/models/transcriber.py
@@ -130,7 +130,7 @@ class AssemblyAITranscriberConfig(
 ):
     buffer_size_seconds: float = 0.1
     word_boost: Optional[List[str]] = None
-    end_utterance_silence_threshold: Optional[int] = None
+    end_utterance_silence_threshold_milliseconds: Optional[int] = None
 
 
 class WhisperCPPTranscriberConfig(

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -54,7 +54,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
             )
         self._ended = False
         self.logger = logger or logging.getLogger(__name__)
-        if self.transcriber_config.endpointing_config:
+        if self.transcriber_config.endpointing_config.time_cutoff_seconds:
             self.transcriber_config.end_utterance_silence_threshold_milliseconds = int(self.transcriber_config.endpointing_config.time_cutoff_seconds * 1000)
 
         self.buffer = bytearray()

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -55,7 +55,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
         self._ended = False
         self.logger = logger or logging.getLogger(__name__)
         if self.transcriber_config.endpointing_config:
-            raise Exception("Assembly AI endpointing config not supported yet")
+            self.transcriber_config.end_utterance_silence_threshold = int(self.transcriber_config.endpointing_config.time_cutoff_seconds * 1000)
 
         self.buffer = bytearray()
         self.audio_cursor = 0

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -60,7 +60,7 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
         self.buffer = bytearray()
         self.audio_cursor = 0
         self.terminate_msg = json.dumps({"terminate_session": True})
-        self.threshold_msg = (
+        self.end_utterance_silence_threshold_msg = (
             None if self.transcriber_config.end_utterance_silence_threshold is None 
             else json.dumps(
                 {"end_utterance_silence_threshold": self.transcriber_config.end_utterance_silence_threshold}
@@ -113,8 +113,8 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
         ) as ws:
             await asyncio.sleep(0.1)
 
-            if self.threshold_msg:
-                await ws.send(self.threshold_msg)
+            if self.end_utterance_silence_threshold_msg:
+                await ws.send(self.end_utterance_silence_threshold_msg)
 
             async def sender(ws):  # sends audio to websocket
                 while not self._ended:

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -8,7 +8,7 @@ import numpy as np
 from urllib.parse import urlencode
 from vocode import getenv
 
-from vocode.streaming.models.transcriber import AssemblyAITranscriberConfig
+from vocode.streaming.models.transcriber import AssemblyAITranscriberConfig, TimeEndpointingConfig, PunctuationEndpointingConfig
 from vocode.streaming.models.websocket import AudioMessage
 from vocode.streaming.transcriber.base_transcriber import (
     BaseAsyncTranscriber,

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -55,15 +55,15 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
         self._ended = False
         self.logger = logger or logging.getLogger(__name__)
         if self.transcriber_config.endpointing_config:
-            self.transcriber_config.end_utterance_silence_threshold = int(self.transcriber_config.endpointing_config.time_cutoff_seconds * 1000)
+            self.transcriber_config.end_utterance_silence_threshold_milliseconds = int(self.transcriber_config.endpointing_config.time_cutoff_seconds * 1000)
 
         self.buffer = bytearray()
         self.audio_cursor = 0
         self.terminate_msg = json.dumps({"terminate_session": True})
         self.end_utterance_silence_threshold_msg = (
-            None if self.transcriber_config.end_utterance_silence_threshold is None 
+            None if self.transcriber_config.end_utterance_silence_threshold_milliseconds is None 
             else json.dumps(
-                {"end_utterance_silence_threshold": self.transcriber_config.end_utterance_silence_threshold}
+                {"end_utterance_silence_threshold": self.transcriber_config.end_utterance_silence_threshold_milliseconds}
             )
         )
 

--- a/vocode/streaming/transcriber/assembly_ai_transcriber.py
+++ b/vocode/streaming/transcriber/assembly_ai_transcriber.py
@@ -54,11 +54,11 @@ class AssemblyAITranscriber(BaseAsyncTranscriber[AssemblyAITranscriberConfig]):
             )
         self._ended = False
         self.logger = logger or logging.getLogger(__name__)
-        if self.transcriber_config.endpointing_config.time_cutoff_seconds:
-            self.transcriber_config.end_utterance_silence_threshold_milliseconds = int(self.transcriber_config.endpointing_config.time_cutoff_seconds * 1000)
-
         self.buffer = bytearray()
         self.audio_cursor = 0
+
+        if isinstance(self.transcriber_config.endpointing_config, (TimeEndpointingConfig, PunctuationEndpointingConfig)):
+            self.transcriber_config.end_utterance_silence_threshold_milliseconds = int(self.transcriber_config.endpointing_config.time_cutoff_seconds * 1000)
         self.terminate_msg = json.dumps({"terminate_session": True})
         self.end_utterance_silence_threshold_msg = (
             None if self.transcriber_config.end_utterance_silence_threshold_milliseconds is None 


### PR DESCRIPTION
- End of utterance detection allows users to specify the duration of silence to trigger a `FinalTranscript` from AssemblyAI.
- Remove string encoding for `terminate_msg`