### PR TITLE
Update google_synthesizer to use texttospeech_v1beta1

### DIFF
--- a/vocode/streaming/synthesizer/google_synthesizer.py
+++ b/vocode/streaming/synthesizer/google_synthesizer.py
@@ -33,7 +33,7 @@ class GoogleSynthesizer(BaseSynthesizer[GoogleSynthesizerConfig]):
     ):
         super().__init__(synthesizer_config, aiohttp_session)
 
-        from google.cloud import texttospeech as tts
+        from google.cloud import texttospeech_v1beta1 as tts
         import google.auth
 
         google.auth.default()


### PR DESCRIPTION
Replace google.cloud texttospeech with texttospeech_v1beta1; otherwise you will get an error on self.tts.SynthesizeSpeechRequest.TimepointType.SSML_MARK