### PR TITLE
Add Camb.ai TTS synthesizer integration

### DIFF
--- a/tests/streaming/synthesizer/test_camb_ai_synthesizer.py
+++ b/tests/streaming/synthesizer/test_camb_ai_synthesizer.py
@@ -1,0 +1,160 @@
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic.v1 import ValidationError
+from pytest_mock import MockerFixture
+
+from vocode.streaming.models.audio import AudioEncoding
+from vocode.streaming.models.synthesizer import CambAiSynthesizerConfig
+from vocode.streaming.synthesizer.camb_ai_synthesizer import CambAiSynthesizer
+from vocode.streaming.synthesizer.default_factory import DefaultSynthesizerFactory
+
+DEFAULT_PARAMS = {
+    "sampling_rate": 24000,
+    "audio_encoding": AudioEncoding.LINEAR16,
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_async_requestor(mocker: MockerFixture):
+    """Mock AsyncRequestor to avoid needing an event loop for non-async tests."""
+    mocker.patch(
+        "vocode.streaming.synthesizer.base_synthesizer.AsyncRequestor",
+        return_value=MagicMock(),
+    )
+
+
+def test_camb_ai_synthesizer_config_defaults():
+    config = CambAiSynthesizerConfig(**DEFAULT_PARAMS)
+    assert config.voice_id == 2681  # DEFAULT_CAMB_AI_VOICE_ID
+    assert config.model_id == "mars-8-flash"
+    assert config.language == "en-us"  # DEFAULT_CAMB_AI_LANGUAGE
+    assert config.speed == 1.0
+    assert config.user_instructions is None
+
+
+def test_camb_ai_synthesizer_config_custom_values():
+    config = CambAiSynthesizerConfig(
+        **DEFAULT_PARAMS,
+        api_key="test_key",
+        voice_id=1234,
+        model_id="mars-8",
+        language="fr-fr",
+        speed=1.5,
+    )
+    assert config.api_key == "test_key"
+    assert config.voice_id == 1234
+    assert config.model_id == "mars-8"
+    assert config.language == "fr-fr"
+    assert config.speed == 1.5
+
+
+def test_camb_ai_synthesizer_config_user_instructions_requires_instruct_model():
+    with pytest.raises(ValidationError) as exc_info:
+        CambAiSynthesizerConfig(
+            **DEFAULT_PARAMS,
+            model_id="mars-8-flash",
+            user_instructions="Speak slowly and clearly.",
+        )
+    assert "user_instructions is only supported with mars-8-instruct model" in str(exc_info.value)
+
+
+def test_camb_ai_synthesizer_config_user_instructions_with_instruct_model():
+    config = CambAiSynthesizerConfig(
+        **DEFAULT_PARAMS,
+        model_id="mars-8-instruct",
+        user_instructions="Speak slowly and clearly.",
+    )
+    assert config.user_instructions == "Speak slowly and clearly."
+
+
+def test_camb_ai_synthesizer_config_user_instructions_length_validation():
+    with pytest.raises(ValidationError) as exc_info:
+        CambAiSynthesizerConfig(
+            **DEFAULT_PARAMS,
+            model_id="mars-8-instruct",
+            user_instructions="ab",
+        )
+    assert "must be between 3 and 1000 characters" in str(exc_info.value)
+
+
+def test_camb_ai_synthesizer_requires_api_key():
+    config = CambAiSynthesizerConfig(**DEFAULT_PARAMS)
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("vocode.getenv", return_value=None):
+            with pytest.raises(ValueError) as exc_info:
+                CambAiSynthesizer(config)
+            assert "Camb.ai API key is required" in str(exc_info.value)
+
+
+def test_camb_ai_synthesizer_uses_config_api_key():
+    config = CambAiSynthesizerConfig(**DEFAULT_PARAMS, api_key="config_api_key")
+    with patch("vocode.getenv", return_value=None):
+        synthesizer = CambAiSynthesizer(config)
+        assert synthesizer.api_key == "config_api_key"
+
+
+def test_camb_ai_synthesizer_uses_env_api_key():
+    config = CambAiSynthesizerConfig(**DEFAULT_PARAMS)
+    with patch(
+        "vocode.streaming.synthesizer.camb_ai_synthesizer.getenv", return_value="env_api_key"
+    ):
+        synthesizer = CambAiSynthesizer(config)
+        assert synthesizer.api_key == "env_api_key"
+
+
+def test_camb_ai_synthesizer_voice_identifier():
+    config = CambAiSynthesizerConfig(
+        **DEFAULT_PARAMS,
+        api_key="test_key",
+        voice_id=2681,
+        model_id="mars-8-flash",
+        language="en-us",
+        speed=1.0,
+    )
+    voice_id = CambAiSynthesizer.get_voice_identifier(config)
+
+    hashed_api_key = hashlib.sha256("test_key".encode("utf-8")).hexdigest()
+    expected = f"camb_ai:{hashed_api_key}:2681:mars-8-flash:en-us:1.0:linear16"
+    assert voice_id == expected
+
+
+def test_camb_ai_synthesizer_needs_resample_for_non_24k():
+    config = CambAiSynthesizerConfig(
+        sampling_rate=16000,
+        audio_encoding=AudioEncoding.LINEAR16,
+        api_key="test_key",
+    )
+    synthesizer = CambAiSynthesizer(config)
+    assert synthesizer.needs_resample is True
+    assert synthesizer.target_sample_rate == 16000
+
+
+def test_camb_ai_synthesizer_no_resample_for_24k():
+    config = CambAiSynthesizerConfig(
+        sampling_rate=24000,
+        audio_encoding=AudioEncoding.LINEAR16,
+        api_key="test_key",
+    )
+    synthesizer = CambAiSynthesizer(config)
+    assert synthesizer.needs_resample is False
+
+
+def test_camb_ai_synthesizer_mulaw_needs_resample():
+    config = CambAiSynthesizerConfig(
+        sampling_rate=8000,
+        audio_encoding=AudioEncoding.MULAW,
+        api_key="test_key",
+    )
+    synthesizer = CambAiSynthesizer(config)
+    assert synthesizer.needs_resample is True
+
+
+def test_factory_creates_camb_ai_synthesizer(mocker: MockerFixture):
+    factory = DefaultSynthesizerFactory()
+
+    constructor = mocker.patch("vocode.streaming.synthesizer.default_factory.CambAiSynthesizer")
+
+    factory.create_synthesizer(CambAiSynthesizerConfig(**DEFAULT_PARAMS, api_key="test_key"))
+    constructor.assert_called_once()

--- a/tests/streaming/synthesizer/test_camb_ai_synthesizer.py
+++ b/tests/streaming/synthesizer/test_camb_ai_synthesizer.py
@@ -11,7 +11,7 @@ from vocode.streaming.synthesizer.camb_ai_synthesizer import CambAiSynthesizer
 from vocode.streaming.synthesizer.default_factory import DefaultSynthesizerFactory
 
 DEFAULT_PARAMS = {
-    "sampling_rate": 24000,
+    "sampling_rate": 22050,  # mars-flash native sample rate
     "audio_encoding": AudioEncoding.LINEAR16,
 }
 
@@ -27,11 +27,11 @@ def mock_async_requestor(mocker: MockerFixture):
 
 def test_camb_ai_synthesizer_config_defaults():
     config = CambAiSynthesizerConfig(**DEFAULT_PARAMS)
-    assert config.voice_id == 2681  # DEFAULT_CAMB_AI_VOICE_ID
-    assert config.model_id == "mars-8-flash"
+    assert config.voice_id == 147320  # DEFAULT_CAMB_AI_VOICE_ID
+    assert config.model_id == "mars-flash"
     assert config.language == "en-us"  # DEFAULT_CAMB_AI_LANGUAGE
-    assert config.speed == 1.0
     assert config.user_instructions is None
+    assert config.enhance_named_entities_pronunciation is False
 
 
 def test_camb_ai_synthesizer_config_custom_values():
@@ -39,31 +39,31 @@ def test_camb_ai_synthesizer_config_custom_values():
         **DEFAULT_PARAMS,
         api_key="test_key",
         voice_id=1234,
-        model_id="mars-8",
+        model_id="mars-pro",
         language="fr-fr",
-        speed=1.5,
+        enhance_named_entities_pronunciation=True,
     )
     assert config.api_key == "test_key"
     assert config.voice_id == 1234
-    assert config.model_id == "mars-8"
+    assert config.model_id == "mars-pro"
     assert config.language == "fr-fr"
-    assert config.speed == 1.5
+    assert config.enhance_named_entities_pronunciation is True
 
 
 def test_camb_ai_synthesizer_config_user_instructions_requires_instruct_model():
     with pytest.raises(ValidationError) as exc_info:
         CambAiSynthesizerConfig(
             **DEFAULT_PARAMS,
-            model_id="mars-8-flash",
+            model_id="mars-flash",
             user_instructions="Speak slowly and clearly.",
         )
-    assert "user_instructions is only supported with mars-8-instruct model" in str(exc_info.value)
+    assert "user_instructions is only supported with mars-instruct model" in str(exc_info.value)
 
 
 def test_camb_ai_synthesizer_config_user_instructions_with_instruct_model():
     config = CambAiSynthesizerConfig(
         **DEFAULT_PARAMS,
-        model_id="mars-8-instruct",
+        model_id="mars-instruct",
         user_instructions="Speak slowly and clearly.",
     )
     assert config.user_instructions == "Speak slowly and clearly."
@@ -73,7 +73,7 @@ def test_camb_ai_synthesizer_config_user_instructions_length_validation():
     with pytest.raises(ValidationError) as exc_info:
         CambAiSynthesizerConfig(
             **DEFAULT_PARAMS,
-            model_id="mars-8-instruct",
+            model_id="mars-instruct",
             user_instructions="ab",
         )
     assert "must be between 3 and 1000 characters" in str(exc_info.value)
@@ -108,37 +108,55 @@ def test_camb_ai_synthesizer_voice_identifier():
     config = CambAiSynthesizerConfig(
         **DEFAULT_PARAMS,
         api_key="test_key",
-        voice_id=2681,
-        model_id="mars-8-flash",
+        voice_id=147320,
+        model_id="mars-flash",
         language="en-us",
-        speed=1.0,
     )
     voice_id = CambAiSynthesizer.get_voice_identifier(config)
 
     hashed_api_key = hashlib.sha256("test_key".encode("utf-8")).hexdigest()
-    expected = f"camb_ai:{hashed_api_key}:2681:mars-8-flash:en-us:1.0:linear16"
+    expected = f"camb_ai:{hashed_api_key}:147320:mars-flash:en-us:False:linear16"
     assert voice_id == expected
 
 
-def test_camb_ai_synthesizer_needs_resample_for_non_24k():
+def test_camb_ai_synthesizer_needs_resample_for_non_native_rate():
+    # mars-flash native rate is 22050, so 16000 needs resampling
     config = CambAiSynthesizerConfig(
         sampling_rate=16000,
         audio_encoding=AudioEncoding.LINEAR16,
         api_key="test_key",
+        model_id="mars-flash",
     )
     synthesizer = CambAiSynthesizer(config)
     assert synthesizer.needs_resample is True
     assert synthesizer.target_sample_rate == 16000
+    assert synthesizer.native_sample_rate == 22050
 
 
-def test_camb_ai_synthesizer_no_resample_for_24k():
+def test_camb_ai_synthesizer_no_resample_for_native_rate():
+    # mars-flash native rate is 22050
     config = CambAiSynthesizerConfig(
-        sampling_rate=24000,
+        sampling_rate=22050,
         audio_encoding=AudioEncoding.LINEAR16,
         api_key="test_key",
+        model_id="mars-flash",
     )
     synthesizer = CambAiSynthesizer(config)
     assert synthesizer.needs_resample is False
+    assert synthesizer.native_sample_rate == 22050
+
+
+def test_camb_ai_synthesizer_mars_pro_native_rate():
+    # mars-pro native rate is 48000
+    config = CambAiSynthesizerConfig(
+        sampling_rate=48000,
+        audio_encoding=AudioEncoding.LINEAR16,
+        api_key="test_key",
+        model_id="mars-pro",
+    )
+    synthesizer = CambAiSynthesizer(config)
+    assert synthesizer.needs_resample is False
+    assert synthesizer.native_sample_rate == 48000
 
 
 def test_camb_ai_synthesizer_mulaw_needs_resample():

--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -25,6 +25,7 @@ class SynthesizerType(str, Enum):
     BARK = "synthesizer_bark"
     POLLY = "synthesizer_polly"
     CARTESIA = "synthesizer_cartesia"
+    CAMB_AI = "synthesizer_camb_ai"
 
 
 class SentimentConfig(BaseModel):
@@ -245,3 +246,27 @@ class CartesiaSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.CARTESIA
     model_id: str = DEFAULT_CARTESIA_MODEL_ID
     voice_id: str = DEFAULT_CARTESIA_VOICE_ID
     experimental_voice_controls: Optional[CartesiaVoiceControls] = None
+
+
+DEFAULT_CAMB_AI_VOICE_ID = 2681
+DEFAULT_CAMB_AI_LANGUAGE = "en-us"
+CambAiModelId = Literal["mars-8", "mars-8-flash", "mars-8-instruct", "mars-7", "mars-6", "auto"]
+
+
+class CambAiSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.CAMB_AI.value):  # type: ignore
+    api_key: Optional[str] = None
+    voice_id: int = DEFAULT_CAMB_AI_VOICE_ID
+    model_id: CambAiModelId = "mars-8-flash"
+    language: str = DEFAULT_CAMB_AI_LANGUAGE
+    speed: float = 1.0
+    user_instructions: Optional[str] = None
+
+    @validator("user_instructions")
+    def user_instructions_check(cls, user_instructions, values):
+        if user_instructions is not None:
+            if len(user_instructions) < 3 or len(user_instructions) > 1000:
+                raise ValueError("user_instructions must be between 3 and 1000 characters.")
+            model_id = values.get("model_id")
+            if model_id != "mars-8-instruct":
+                raise ValueError("user_instructions is only supported with mars-8-instruct model.")
+        return user_instructions

--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -248,18 +248,25 @@ class CartesiaSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.CARTESIA
     experimental_voice_controls: Optional[CartesiaVoiceControls] = None
 
 
-DEFAULT_CAMB_AI_VOICE_ID = 2681
+DEFAULT_CAMB_AI_VOICE_ID = 147320
 DEFAULT_CAMB_AI_LANGUAGE = "en-us"
-CambAiModelId = Literal["mars-8", "mars-8-flash", "mars-8-instruct", "mars-7", "mars-6", "auto"]
+CambAiModelId = Literal["mars-pro", "mars-flash", "mars-instruct"]
+
+# Model-specific native sample rates
+CAMB_AI_MODEL_SAMPLE_RATES = {
+    "mars-flash": 22050,
+    "mars-pro": 48000,
+    "mars-instruct": 22050,
+}
 
 
 class CambAiSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.CAMB_AI.value):  # type: ignore
     api_key: Optional[str] = None
     voice_id: int = DEFAULT_CAMB_AI_VOICE_ID
-    model_id: CambAiModelId = "mars-8-flash"
+    model_id: CambAiModelId = "mars-flash"
     language: str = DEFAULT_CAMB_AI_LANGUAGE
-    speed: float = 1.0
     user_instructions: Optional[str] = None
+    enhance_named_entities_pronunciation: bool = False
 
     @validator("user_instructions")
     def user_instructions_check(cls, user_instructions, values):
@@ -267,6 +274,6 @@ class CambAiSynthesizerConfig(SynthesizerConfig, type=SynthesizerType.CAMB_AI.va
             if len(user_instructions) < 3 or len(user_instructions) > 1000:
                 raise ValueError("user_instructions must be between 3 and 1000 characters.")
             model_id = values.get("model_id")
-            if model_id != "mars-8-instruct":
-                raise ValueError("user_instructions is only supported with mars-8-instruct model.")
+            if model_id != "mars-instruct":
+                raise ValueError("user_instructions is only supported with mars-instruct model.")
         return user_instructions

--- a/vocode/streaming/synthesizer/camb_ai_synthesizer.py
+++ b/vocode/streaming/synthesizer/camb_ai_synthesizer.py
@@ -6,14 +6,13 @@ from typing import Optional
 from loguru import logger
 
 from vocode import getenv
-from vocode.streaming.models.audio import AudioEncoding, SamplingRate
+from vocode.streaming.models.audio import AudioEncoding
 from vocode.streaming.models.message import BaseMessage
-from vocode.streaming.models.synthesizer import CambAiSynthesizerConfig
+from vocode.streaming.models.synthesizer import CAMB_AI_MODEL_SAMPLE_RATES, CambAiSynthesizerConfig
 from vocode.streaming.synthesizer.base_synthesizer import BaseSynthesizer, SynthesisResult
 from vocode.streaming.utils.create_task import asyncio_create_task
 
 CAMB_AI_BASE_URL = "https://client.camb.ai/apis"
-CAMB_AI_NATIVE_SAMPLE_RATE = 24000
 
 
 class CambAiException(Exception):
@@ -37,16 +36,18 @@ class CambAiSynthesizer(BaseSynthesizer[CambAiSynthesizerConfig]):
         self.voice_id = synthesizer_config.voice_id
         self.model_id = synthesizer_config.model_id
         self.language = synthesizer_config.language
-        self.speed = synthesizer_config.speed
         self.user_instructions = synthesizer_config.user_instructions
+        self.enhance_named_entities_pronunciation = synthesizer_config.enhance_named_entities_pronunciation
         self.words_per_minute = 150
 
+        # Get native sample rate for the selected model
+        self.native_sample_rate = CAMB_AI_MODEL_SAMPLE_RATES.get(self.model_id, 22050)
         self.needs_resample = False
         self.target_sample_rate = self.synthesizer_config.sampling_rate
 
         if self.synthesizer_config.audio_encoding == AudioEncoding.LINEAR16:
             self.output_format = "pcm_s16le"
-            if self.synthesizer_config.sampling_rate != CAMB_AI_NATIVE_SAMPLE_RATE:
+            if self.synthesizer_config.sampling_rate != self.native_sample_rate:
                 self.needs_resample = True
         elif self.synthesizer_config.audio_encoding == AudioEncoding.MULAW:
             self.output_format = "pcm_s16le"
@@ -89,12 +90,10 @@ class CambAiSynthesizer(BaseSynthesizer[CambAiSynthesizerConfig]):
             "output_configuration": {
                 "format": self.output_format,
             },
-            "voice_settings": {
-                "speed": self.speed,
-            },
+            "enhance_named_entities_pronunciation": self.enhance_named_entities_pronunciation,
         }
 
-        if self.user_instructions and self.model_id == "mars-8-instruct":
+        if self.user_instructions and self.model_id == "mars-instruct":
             body["user_instructions"] = self.user_instructions
 
         chunk_queue: asyncio.Queue[Optional[bytes]] = asyncio.Queue()
@@ -117,7 +116,7 @@ class CambAiSynthesizer(BaseSynthesizer[CambAiSynthesizerConfig]):
                 str(synthesizer_config.voice_id),
                 str(synthesizer_config.model_id),
                 str(synthesizer_config.language),
-                str(synthesizer_config.speed),
+                str(synthesizer_config.enhance_named_entities_pronunciation),
                 synthesizer_config.audio_encoding,
             )
         )
@@ -151,7 +150,7 @@ class CambAiSynthesizer(BaseSynthesizer[CambAiSynthesizerConfig]):
                 if status_code == 401:
                     raise CambAiException(
                         "Invalid Camb.ai API key. Set CAMB_API_KEY environment variable "
-                        "with your API key from https://camb.ai"
+                        "with your API key from https://docs.camb.ai/"
                     )
                 elif status_code == 403:
                     raise CambAiException(
@@ -174,7 +173,7 @@ class CambAiSynthesizer(BaseSynthesizer[CambAiSynthesizerConfig]):
                 if self.needs_resample:
                     processed_chunk = self._resample_chunk(
                         chunk,
-                        CAMB_AI_NATIVE_SAMPLE_RATE,
+                        self.native_sample_rate,
                         self.target_sample_rate,
                     )
                 if self.synthesizer_config.audio_encoding == AudioEncoding.MULAW:

--- a/vocode/streaming/synthesizer/camb_ai_synthesizer.py
+++ b/vocode/streaming/synthesizer/camb_ai_synthesizer.py
@@ -1,0 +1,186 @@
+import asyncio
+import audioop
+import hashlib
+from typing import Optional
+
+from loguru import logger
+
+from vocode import getenv
+from vocode.streaming.models.audio import AudioEncoding, SamplingRate
+from vocode.streaming.models.message import BaseMessage
+from vocode.streaming.models.synthesizer import CambAiSynthesizerConfig
+from vocode.streaming.synthesizer.base_synthesizer import BaseSynthesizer, SynthesisResult
+from vocode.streaming.utils.create_task import asyncio_create_task
+
+CAMB_AI_BASE_URL = "https://client.camb.ai/apis"
+CAMB_AI_NATIVE_SAMPLE_RATE = 24000
+
+
+class CambAiException(Exception):
+    pass
+
+
+class CambAiSynthesizer(BaseSynthesizer[CambAiSynthesizerConfig]):
+    def __init__(
+        self,
+        synthesizer_config: CambAiSynthesizerConfig,
+    ):
+        super().__init__(synthesizer_config)
+
+        self.api_key = synthesizer_config.api_key or getenv("CAMB_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Camb.ai API key is required. Set CAMB_API_KEY environment variable "
+                "or pass api_key in CambAiSynthesizerConfig."
+            )
+
+        self.voice_id = synthesizer_config.voice_id
+        self.model_id = synthesizer_config.model_id
+        self.language = synthesizer_config.language
+        self.speed = synthesizer_config.speed
+        self.user_instructions = synthesizer_config.user_instructions
+        self.words_per_minute = 150
+
+        self.needs_resample = False
+        self.target_sample_rate = self.synthesizer_config.sampling_rate
+
+        if self.synthesizer_config.audio_encoding == AudioEncoding.LINEAR16:
+            self.output_format = "pcm_s16le"
+            if self.synthesizer_config.sampling_rate != CAMB_AI_NATIVE_SAMPLE_RATE:
+                self.needs_resample = True
+        elif self.synthesizer_config.audio_encoding == AudioEncoding.MULAW:
+            self.output_format = "pcm_s16le"
+            self.needs_resample = True
+        else:
+            raise ValueError(
+                f"Unsupported audio encoding: {self.synthesizer_config.audio_encoding}"
+            )
+
+    async def create_speech_uncached(
+        self,
+        message: BaseMessage,
+        chunk_size: int,
+        is_first_text_chunk: bool = False,
+        is_sole_text_chunk: bool = False,
+    ) -> SynthesisResult:
+        text = message.text
+        if len(text) < 3:
+            text = text + "   "
+        if len(text) > 3000:
+            logger.warning(
+                f"Text length {len(text)} exceeds Camb.ai limit of 3000 characters. Truncating."
+            )
+            text = text[:3000]
+
+        self.total_chars += len(message.text)
+
+        url = f"{CAMB_AI_BASE_URL}/tts-stream"
+        headers = {
+            "x-api-key": self.api_key,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        body = {
+            "text": text,
+            "voice_id": self.voice_id,
+            "language": self.language,
+            "speech_model": self.model_id,
+            "output_configuration": {
+                "format": self.output_format,
+            },
+            "voice_settings": {
+                "speed": self.speed,
+            },
+        }
+
+        if self.user_instructions and self.model_id == "mars-8-instruct":
+            body["user_instructions"] = self.user_instructions
+
+        chunk_queue: asyncio.Queue[Optional[bytes]] = asyncio.Queue()
+        asyncio_create_task(
+            self.get_chunks(url, headers, body, chunk_size, chunk_queue),
+        )
+
+        return SynthesisResult(
+            self.chunk_result_generator_from_queue(chunk_queue),
+            lambda seconds: self.get_message_cutoff_from_voice_speed(message, seconds, 150),
+        )
+
+    @classmethod
+    def get_voice_identifier(cls, synthesizer_config: CambAiSynthesizerConfig) -> str:
+        hashed_api_key = hashlib.sha256(f"{synthesizer_config.api_key}".encode("utf-8")).hexdigest()
+        return ":".join(
+            (
+                "camb_ai",
+                hashed_api_key,
+                str(synthesizer_config.voice_id),
+                str(synthesizer_config.model_id),
+                str(synthesizer_config.language),
+                str(synthesizer_config.speed),
+                synthesizer_config.audio_encoding,
+            )
+        )
+
+    async def get_chunks(
+        self,
+        url: str,
+        headers: dict,
+        body: dict,
+        chunk_size: int,
+        chunk_queue: asyncio.Queue[Optional[bytes]],
+    ):
+        try:
+            async_client = self.async_requestor.get_client()
+            stream = await async_client.send(
+                async_client.build_request(
+                    "POST",
+                    url,
+                    headers=headers,
+                    json=body,
+                    timeout=60.0,
+                ),
+                stream=True,
+            )
+
+            if not stream.is_success:
+                error = await stream.aread()
+                error_message = error.decode("utf-8")
+                status_code = stream.status_code
+
+                if status_code == 401:
+                    raise CambAiException(
+                        "Invalid Camb.ai API key. Set CAMB_API_KEY environment variable "
+                        "with your API key from https://camb.ai"
+                    )
+                elif status_code == 403:
+                    raise CambAiException(
+                        f"Voice ID {self.voice_id} is not accessible with your API key. "
+                        "Use Camb.ai's list-voices endpoint to see available voices."
+                    )
+                elif status_code == 404:
+                    raise CambAiException(f"Invalid voice ID: {self.voice_id}")
+                elif status_code == 429:
+                    raise CambAiException(
+                        "Camb.ai rate limit exceeded. Please wait before making more requests."
+                    )
+                else:
+                    raise CambAiException(
+                        f"Camb.ai API returned {status_code} status code: {error_message}"
+                    )
+
+            async for chunk in stream.aiter_bytes(chunk_size):
+                processed_chunk = chunk
+                if self.needs_resample:
+                    processed_chunk = self._resample_chunk(
+                        chunk,
+                        CAMB_AI_NATIVE_SAMPLE_RATE,
+                        self.target_sample_rate,
+                    )
+                if self.synthesizer_config.audio_encoding == AudioEncoding.MULAW:
+                    processed_chunk = audioop.lin2ulaw(processed_chunk, 2)
+                chunk_queue.put_nowait(processed_chunk)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            chunk_queue.put_nowait(None)

--- a/vocode/streaming/synthesizer/default_factory.py
+++ b/vocode/streaming/synthesizer/default_factory.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from vocode.streaming.models.synthesizer import (
     AzureSynthesizerConfig,
+    CambAiSynthesizerConfig,
     CartesiaSynthesizerConfig,
     ElevenLabsSynthesizerConfig,
     PlayHtSynthesizerConfig,
@@ -12,6 +13,7 @@ from vocode.streaming.models.synthesizer import (
 from vocode.streaming.synthesizer.abstract_factory import AbstractSynthesizerFactory
 from vocode.streaming.synthesizer.azure_synthesizer import AzureSynthesizer
 from vocode.streaming.synthesizer.base_synthesizer import BaseSynthesizer
+from vocode.streaming.synthesizer.camb_ai_synthesizer import CambAiSynthesizer
 from vocode.streaming.synthesizer.cartesia_synthesizer import CartesiaSynthesizer
 from vocode.streaming.synthesizer.eleven_labs_synthesizer import ElevenLabsSynthesizer
 from vocode.streaming.synthesizer.eleven_labs_websocket_synthesizer import ElevenLabsWSSynthesizer
@@ -28,6 +30,8 @@ class DefaultSynthesizerFactory(AbstractSynthesizerFactory):
     ):
         if isinstance(synthesizer_config, AzureSynthesizerConfig):
             return AzureSynthesizer(synthesizer_config)
+        elif isinstance(synthesizer_config, CambAiSynthesizerConfig):
+            return CambAiSynthesizer(synthesizer_config)
         elif isinstance(synthesizer_config, CartesiaSynthesizerConfig):
             return CartesiaSynthesizer(synthesizer_config)
         elif isinstance(synthesizer_config, ElevenLabsSynthesizerConfig):


### PR DESCRIPTION
## Summary

Adds support for [Camb.ai](https://camb.ai)'s text-to-speech API as a new synthesizer option.

### Features
- Streaming HTTP audio output with `asyncio.Queue` for low-latency playback
- Support for Mars models (`mars-flash`, `mars-pro`, `mars-instruct`)
- Model-specific native sample rates (mars-flash/instruct: 22050Hz, mars-pro: 48000Hz)
- Automatic sample rate resampling to target output rate
- MULAW encoding support for telephony
- Voice parameters: `voice_id`, `language`, `user_instructions`, `enhance_named_entities_pronunciation`
- Comprehensive error handling for API errors (401, 403, 404, 429)

### Usage

```python
from vocode.streaming.models.audio import AudioEncoding
from vocode.streaming.models.synthesizer import CambAiSynthesizerConfig
from vocode.streaming.synthesizer.camb_ai_synthesizer import CambAiSynthesizer

config = CambAiSynthesizerConfig(
    sampling_rate=22050,
    audio_encoding=AudioEncoding.LINEAR16,
    voice_id=147320,
    model_id="mars-flash",  # Fast inference (default)
    language="en-us",
    enhance_named_entities_pronunciation=True,  # Optional
)
synthesizer = CambAiSynthesizer(config)
```

### Environment Variables
- `CAMB_API_KEY` - API key from https://camb.ai

### Files Changed
- `vocode/streaming/models/synthesizer.py` - Added `SynthesizerType.CAMB_AI` and `CambAiSynthesizerConfig`
- `vocode/streaming/synthesizer/camb_ai_synthesizer.py` - New synthesizer implementation
- `vocode/streaming/synthesizer/default_factory.py` - Registered new synthesizer
- `tests/streaming/synthesizer/test_camb_ai_synthesizer.py` - Unit tests (14 tests)

## Test plan
- [x] All 14 unit tests pass (`poetry run pytest tests/streaming/synthesizer/test_camb_ai_synthesizer.py`)
- [x] Manual integration test with real API key verified audio output
- [x] Factory correctly instantiates `CambAiSynthesizer`